### PR TITLE
Revert BuyerUID rename

### DIFF
--- a/bidrequest_test.go
+++ b/bidrequest_test.go
@@ -53,7 +53,8 @@ var _ = Describe("BidRequest", func() {
 				FlashVer: "10.1",
 			},
 			User: &User{
-				ID: "45asdf987656789adfad4678rew656789",
+				ID:       "45asdf987656789adfad4678rew656789",
+				BuyerUID: "5df678asd8987656asdf78987654",
 			},
 			AuctionType: 2,
 			TMax:        120,

--- a/openrtb.go
+++ b/openrtb.go
@@ -210,7 +210,7 @@ type Geo struct {
 // frequency capping and retargeting.
 type User struct {
 	ID         string          `json:"id,omitempty"`         // Unique consumer ID of this user on the exchange
-	BuyerID    string          `json:"buyerid,omitempty"`    // Buyer-specific ID for the user as mapped by the exchange for the buyer. At least one of buyerid or id is recommended.
+	BuyerUID   string          `json:"buyeruid,omitempty"`   // Buyer-specific ID for the user as mapped by the exchange for the buyer. At least one of buyeruid or id is recommended.
 	YOB        int             `json:"yob,omitempty"`        // Year of birth as a 4-digit integer.
 	Gender     string          `json:"gender,omitempty"`     // Gender ("M": male, "F" female, "O" Other)
 	Keywords   string          `json:"keywords,omitempty"`   // Comma separated list of keywords, interests, or intent


### PR DESCRIPTION
`buyerid` was a typo on the OpenRTB v2.3 spec
https://groups.google.com/forum/#!topic/openrtb-user/VrS4aY9wYD4
it should always be `buyeruid`