### PR TITLE
Fix field name

### DIFF
--- a/bid.go
+++ b/bid.go
@@ -31,7 +31,7 @@ type Bid struct {
 	CreativeID string          `json:"crid,omitempty"`    // Creative ID for reporting content issues or defects. This could also be used as a reference to a creative ID that is posted with an exchange.
 	Cat        []string        `json:"cat,omitempty"`     // IAB content categories of the creative. Refer to List 5.1
 	Attr       []int           `json:"attr,omitempty"`    // Array of creative attributes.
-	DealID     string          `json:"deal_id,omitempty"` // DealID extension of private marketplace deals
+	DealID     string          `json:"dealid,omitempty"` // DealID extension of private marketplace deals
 	H          int             `json:"h,omitempty"`       // Height of the ad in pixels.
 	W          int             `json:"w,omitempty"`       // Width of the ad in pixels.
 	Ext        json.RawMessage `json:"ext,omitempty"`

--- a/bid_test.go
+++ b/bid_test.go
@@ -25,6 +25,7 @@ var _ = Describe("Bid", func() {
 			IURL:       "http://ads.com/112770_1386565997.jpeg",
 			CampaignID: "52a5516d29e435137c6f6e74",
 			CreativeID: "52a5516d29e435137c6f6e74_1386565997",
+			DealID:     "example_deal",
 			Attr:       []int{},
 		}))
 	})

--- a/testdata/bid.json
+++ b/testdata/bid.json
@@ -11,5 +11,6 @@
   "iurl": "http://ads.com/112770_1386565997.jpeg",
   "cid": "52a5516d29e435137c6f6e74",
   "crid": "52a5516d29e435137c6f6e74_1386565997",
+  "dealid": "example_deal",
   "attr": []
 }


### PR DESCRIPTION
Fixes `deal_id`, which is supposed to be `dealid` according to http://www.iab.net/media/file/OpenRTB-API-Specification-Version-2-3.pdf (p27).