### PR TITLE
Expose Test attribute for BidRequest

### DIFF
--- a/bidrequest.go
+++ b/bidrequest.go
@@ -22,6 +22,7 @@ type BidRequest struct {
 	App         *App            `json:"app,omitempty"`
 	Device      *Device         `json:"device,omitempty"`
 	User        *User           `json:"user,omitempty"`
+	Test        int             `json:"test,omitempty"`    // Indicator of test mode in which auctions are not billable, where 0 = live mode, 1 = test mode
 	AuctionType int             `json:"at"`                // Auction type, where 1 = First Price, 2 = Second Price Plus. Exchange-specific auction types can be defined using values greater than 500.
 	TMax        int             `json:"tmax,omitempty"`    // Maximum amount of time in milliseconds to submit a bid
 	WSeat       []string        `json:"wseat,omitempty"`   // Array of buyer seats allowed to bid on this auction

--- a/bidrequest_test.go
+++ b/bidrequest_test.go
@@ -56,6 +56,7 @@ var _ = Describe("BidRequest", func() {
 				ID:       "45asdf987656789adfad4678rew656789",
 				BuyerUID: "5df678asd8987656asdf78987654",
 			},
+			Test:        1,
 			AuctionType: 2,
 			TMax:        120,
 			BAdv:        []string{"company1.com", "company2.com"},

--- a/testdata/breq.banner.json
+++ b/testdata/breq.banner.json
@@ -48,5 +48,6 @@
   "user": {
     "id": "45asdf987656789adfad4678rew656789",
     "buyeruid": "5df678asd8987656asdf78987654"
-  }
+  },
+  "test": 1
 }


### PR DESCRIPTION
See 3.2.1 Object: BidRequest, attribute `test`