### PR TITLE
Use custom Extension type instead of json.RawMessage for "ext" fields

### DIFF
--- a/banner.go
+++ b/banner.go
@@ -1,7 +1,5 @@
 package openrtb
 
-import "encoding/json"
-
 // The "banner" object must be included directly in the impression object if the impression offered
 // for auction is display or rich media, or it may be optionally embedded in the video object to
 // describe the companion banners available for the linear or non-linear video ad.  The banner
@@ -9,19 +7,19 @@ import "encoding/json"
 // VAST response to dictate placement of the companion creatives when multiple companion ad
 // opportunities of the same size are available on a page.
 type Banner struct {
-	W        int             `json:"w,omitempty"`        // Width
-	H        int             `json:"h,omitempty"`        // Height
-	WMax     int             `json:"wmax,omitempty"`     // Width maximum
-	HMax     int             `json:"hmax,omitempty"`     // Height maximum
-	WMin     int             `json:"wmin,omitempty"`     // Width minimum
-	HMin     int             `json:"hmin,omitempty"`     // Height minimum
-	ID       string          `json:"id,omitempty"`       // A unique identifier
-	Pos      int             `json:"pos,omitempty"`      // Ad Position
-	BType    []int           `json:"btype,omitempty"`    // Blocked creative types
-	BAttr    []int           `json:"battr,omitempty"`    // Blocked creative attributes
-	Mimes    []string        `json:"mimes,omitempty"`    // Whitelist of content MIME types supported
-	TopFrame int             `json:"topframe,omitempty"` // Default: 0 ("1": Delivered in top frame, "0": Elsewhere)
-	ExpDir   []int           `json:"expdir,omitempty"`   // Specify properties for an expandable ad
-	Api      []int           `json:"api,omitempty"`      // List of supported API frameworks
-	Ext      json.RawMessage `json:"ext,omitempty"`
+	W        int       `json:"w,omitempty"`        // Width
+	H        int       `json:"h,omitempty"`        // Height
+	WMax     int       `json:"wmax,omitempty"`     // Width maximum
+	HMax     int       `json:"hmax,omitempty"`     // Height maximum
+	WMin     int       `json:"wmin,omitempty"`     // Width minimum
+	HMin     int       `json:"hmin,omitempty"`     // Height minimum
+	ID       string    `json:"id,omitempty"`       // A unique identifier
+	Pos      int       `json:"pos,omitempty"`      // Ad Position
+	BType    []int     `json:"btype,omitempty"`    // Blocked creative types
+	BAttr    []int     `json:"battr,omitempty"`    // Blocked creative attributes
+	Mimes    []string  `json:"mimes,omitempty"`    // Whitelist of content MIME types supported
+	TopFrame int       `json:"topframe,omitempty"` // Default: 0 ("1": Delivered in top frame, "0": Elsewhere)
+	ExpDir   []int     `json:"expdir,omitempty"`   // Specify properties for an expandable ad
+	Api      []int     `json:"api,omitempty"`      // List of supported API frameworks
+	Ext      Extension `json:"ext,omitempty"`
 }

--- a/bid.go
+++ b/bid.go
@@ -1,9 +1,6 @@
 package openrtb
 
-import (
-	"encoding/json"
-	"errors"
-)
+import "errors"
 
 // Validation errors
 var (
@@ -19,22 +16,22 @@ var (
 // Cid can be used to block ads that were previously identified as inappropriate.
 // Substitution macros may allow a bidder to use a static notice URL for all of its bids.
 type Bid struct {
-	ID         string          `json:"id"`
-	ImpID      string          `json:"impid"`             // Required string ID of the impression object to which this bid applies.
-	Price      float64         `json:"price"`             // Bid price in CPM. Suggests using integer math for accounting to avoid rounding errors.
-	AdID       string          `json:"adid,omitempty"`    // References the ad to be served if the bid wins.
-	NURL       string          `json:"nurl,omitempty"`    // Win notice URL.
-	AdMarkup   string          `json:"adm,omitempty"`     // Actual ad markup. XHTML if a response to a banner object, or VAST XML if a response to a video object.
-	AdvDomain  []string        `json:"adomain,omitempty"` // Advertiser’s primary or top-level domain for advertiser checking; or multiple if imp rotating.
-	IURL       string          `json:"iurl,omitempty"`    // Sample image URL.
-	CampaignID string          `json:"cid,omitempty"`     // Campaign ID that appears with the Ad markup.
-	CreativeID string          `json:"crid,omitempty"`    // Creative ID for reporting content issues or defects. This could also be used as a reference to a creative ID that is posted with an exchange.
-	Cat        []string        `json:"cat,omitempty"`     // IAB content categories of the creative. Refer to List 5.1
-	Attr       []int           `json:"attr,omitempty"`    // Array of creative attributes.
-	DealID     string          `json:"dealid,omitempty"` // DealID extension of private marketplace deals
-	H          int             `json:"h,omitempty"`       // Height of the ad in pixels.
-	W          int             `json:"w,omitempty"`       // Width of the ad in pixels.
-	Ext        json.RawMessage `json:"ext,omitempty"`
+	ID         string    `json:"id"`
+	ImpID      string    `json:"impid"`             // Required string ID of the impression object to which this bid applies.
+	Price      float64   `json:"price"`             // Bid price in CPM. Suggests using integer math for accounting to avoid rounding errors.
+	AdID       string    `json:"adid,omitempty"`    // References the ad to be served if the bid wins.
+	NURL       string    `json:"nurl,omitempty"`    // Win notice URL.
+	AdMarkup   string    `json:"adm,omitempty"`     // Actual ad markup. XHTML if a response to a banner object, or VAST XML if a response to a video object.
+	AdvDomain  []string  `json:"adomain,omitempty"` // Advertiser’s primary or top-level domain for advertiser checking; or multiple if imp rotating.
+	IURL       string    `json:"iurl,omitempty"`    // Sample image URL.
+	CampaignID string    `json:"cid,omitempty"`     // Campaign ID that appears with the Ad markup.
+	CreativeID string    `json:"crid,omitempty"`    // Creative ID for reporting content issues or defects. This could also be used as a reference to a creative ID that is posted with an exchange.
+	Cat        []string  `json:"cat,omitempty"`     // IAB content categories of the creative. Refer to List 5.1
+	Attr       []int     `json:"attr,omitempty"`    // Array of creative attributes.
+	DealID     string    `json:"dealid,omitempty"`  // DealID extension of private marketplace deals
+	H          int       `json:"h,omitempty"`       // Height of the ad in pixels.
+	W          int       `json:"w,omitempty"`       // Width of the ad in pixels.
+	Ext        Extension `json:"ext,omitempty"`
 }
 
 // Validate required attributes

--- a/bidrequest.go
+++ b/bidrequest.go
@@ -1,9 +1,6 @@
 package openrtb
 
-import (
-	"encoding/json"
-	"errors"
-)
+import "errors"
 
 // Validation errors
 var (
@@ -16,22 +13,22 @@ var (
 // attribute is required as is at least one "imp" (i.e., impression) object.  Other attributes are
 // optional since an exchange may establish default values.
 type BidRequest struct {
-	ID          string          `json:"id"` // Unique ID of the bid request
-	Imp         []Impression    `json:"imp,omitempty"`
-	Site        *Site           `json:"site,omitempty"`
-	App         *App            `json:"app,omitempty"`
-	Device      *Device         `json:"device,omitempty"`
-	User        *User           `json:"user,omitempty"`
-	Test        int             `json:"test,omitempty"`    // Indicator of test mode in which auctions are not billable, where 0 = live mode, 1 = test mode
-	AuctionType int             `json:"at"`                // Auction type, where 1 = First Price, 2 = Second Price Plus. Exchange-specific auction types can be defined using values greater than 500.
-	TMax        int             `json:"tmax,omitempty"`    // Maximum amount of time in milliseconds to submit a bid
-	WSeat       []string        `json:"wseat,omitempty"`   // Array of buyer seats allowed to bid on this auction
-	AllImps     int             `json:"allimps,omitempty"` // Flag to indicate whether exchange can verify that all impressions offered represent all of the impressions available in context, Default: 0
-	Cur         []string        `json:"cur,omitempty"`     // Array of allowed currencies
-	Bcat        []string        `json:"bcat,omitempty"`    // Blocked Advertiser Categories.
-	BAdv        []string        `json:"badv,omitempty"`    // Array of strings of blocked toplevel domains of advertisers
-	Regs        *Regulations    `json:"regs,omitempty"`
-	Ext         json.RawMessage `json:"ext,omitempty"`
+	ID          string       `json:"id"` // Unique ID of the bid request
+	Imp         []Impression `json:"imp,omitempty"`
+	Site        *Site        `json:"site,omitempty"`
+	App         *App         `json:"app,omitempty"`
+	Device      *Device      `json:"device,omitempty"`
+	User        *User        `json:"user,omitempty"`
+	Test        int          `json:"test,omitempty"`    // Indicator of test mode in which auctions are not billable, where 0 = live mode, 1 = test mode
+	AuctionType int          `json:"at"`                // Auction type, where 1 = First Price, 2 = Second Price Plus. Exchange-specific auction types can be defined using values greater than 500.
+	TMax        int          `json:"tmax,omitempty"`    // Maximum amount of time in milliseconds to submit a bid
+	WSeat       []string     `json:"wseat,omitempty"`   // Array of buyer seats allowed to bid on this auction
+	AllImps     int          `json:"allimps,omitempty"` // Flag to indicate whether exchange can verify that all impressions offered represent all of the impressions available in context, Default: 0
+	Cur         []string     `json:"cur,omitempty"`     // Array of allowed currencies
+	Bcat        []string     `json:"bcat,omitempty"`    // Blocked Advertiser Categories.
+	BAdv        []string     `json:"badv,omitempty"`    // Array of strings of blocked toplevel domains of advertisers
+	Regs        *Regulations `json:"regs,omitempty"`
+	Ext         Extension    `json:"ext,omitempty"`
 
 	Pmp *Pmp `json:"pmp,omitempty"` // DEPRECATED: kept for backwards compatibility
 }

--- a/bidresponse.go
+++ b/bidresponse.go
@@ -1,9 +1,6 @@
 package openrtb
 
-import (
-	"encoding/json"
-	"errors"
-)
+import "errors"
 
 // Validation errors
 var (
@@ -16,13 +13,13 @@ var (
 // No-Bids on all impressions should be indicated as a HTTP 204 response.
 // For no-bids on specific impressions, the bidder should omit these from the bid response.
 type BidResponse struct {
-	ID         string          `json:"id"`                   // Reflection of the bid request ID for logging purposes
-	SeatBid    []SeatBid       `json:"seatbid"`              // Array of seatbid objects
-	BidID      string          `json:"bidid,omitempty"`      // Optional response tracking ID for bidders
-	Currency   string          `json:"cur,omitempty"`        // Bid currency
-	CustomData string          `json:"customdata,omitempty"` // Encoded user features
-	NBR        int             `json:"nbr,omitempty"`        // Reason for not bidding, where 0 = unknown error, 1 = technical error, 2 = invalid request, 3 = known web spider, 4 = suspected Non-Human Traffic, 5 = cloud, data center, or proxy IP, 6 = unsupported device, 7 = blocked publisher or site, 8 = unmatched user
-	Ext        json.RawMessage `json:"ext,omitempty"`        // Custom specifications in JSon
+	ID         string    `json:"id"`                   // Reflection of the bid request ID for logging purposes
+	SeatBid    []SeatBid `json:"seatbid"`              // Array of seatbid objects
+	BidID      string    `json:"bidid,omitempty"`      // Optional response tracking ID for bidders
+	Currency   string    `json:"cur,omitempty"`        // Bid currency
+	CustomData string    `json:"customdata,omitempty"` // Encoded user features
+	NBR        int       `json:"nbr,omitempty"`        // Reason for not bidding, where 0 = unknown error, 1 = technical error, 2 = invalid request, 3 = known web spider, 4 = suspected Non-Human Traffic, 5 = cloud, data center, or proxy IP, 6 = unsupported device, 7 = blocked publisher or site, 8 = unmatched user
+	Ext        Extension `json:"ext,omitempty"`        // Custom specifications in JSon
 }
 
 // Validate required attributes

--- a/content.go
+++ b/content.go
@@ -1,31 +1,29 @@
 package openrtb
 
-import "encoding/json"
-
 // This object describes the content in which the impression will appear, which may be syndicated or nonsyndicated
 // content. This object may be useful when syndicated content contains impressions and does
 // not necessarily match the publisher's general content. The exchange might or might not have
 // knowledge of the page where the content is running, as a result of the syndication method. For
 // example might be a video impression embedded in an iframe on an unknown web property or device.
 type Content struct {
-	ID                 string          `json:"id,omitempty"`                 // ID uniquely identifying the content.
-	Episode            int             `json:"episode,omitempty"`            // Episode number (typically applies to video content).
-	Title              string          `json:"title,omitempty"`              // Content title.
-	Series             string          `json:"series,omitempty"`             // Content series.
-	Season             string          `json:"season,omitempty"`             // Content season.
-	Producer           *Producer       `json:"producer,omitempty"`           // The producer.
-	URL                string          `json:"url,omitempty"`                // URL of the content, for buy-side contextualization or review.
-	Cat                []string        `json:"cat,omitempty"`                // Array of IAB content categories that describe the content.
-	VideoQuality       int             `json:"videoquality,omitempty"`       // Video quality per IAB's classification.
-	Context            int             `json:"context,omitempty"`            // Type of content (game, video, text, etc.).
-	ContentRating      string          `json:"contentrating,omitempty"`      // Content rating (e.g., MPAA).
-	UserRating         string          `json:"userrating,omitempty"`         // User rating of the content (e.g., number of stars, likes, etc.).
-	QAGMediaRating     int             `json:"qagmediarating,omitempty"`     // Media rating per QAG guidelines.
-	Keywords           string          `json:"keywords,omitempty"`           // Comma separated list of keywords describing the content.
-	LiveStream         int             `json:"livestream,omitempty"`         // 0 = not live, 1 = content is live (e.g., stream, live blog).
-	SourceRelationship int             `json:"sourcerelationship,omitempty"` // 0 = indirect, 1 = direct.
-	Len                int             `json:"len,omitempty"`                // Length of content in seconds; appropriate for video or audio.
-	Language           string          `json:"language,omitempty"`           // Content language using ISO-639-1-alpha-2.
-	Embeddable         int             `json:"embeddable,omitempty"`         // Indicator of whether or not the content is embeddable (e.g., an embeddable video player), where 0 = no, 1 = yes.
-	Ext                json.RawMessage `json:"ext,omitempty"`
+	ID                 string    `json:"id,omitempty"`                 // ID uniquely identifying the content.
+	Episode            int       `json:"episode,omitempty"`            // Episode number (typically applies to video content).
+	Title              string    `json:"title,omitempty"`              // Content title.
+	Series             string    `json:"series,omitempty"`             // Content series.
+	Season             string    `json:"season,omitempty"`             // Content season.
+	Producer           *Producer `json:"producer,omitempty"`           // The producer.
+	URL                string    `json:"url,omitempty"`                // URL of the content, for buy-side contextualization or review.
+	Cat                []string  `json:"cat,omitempty"`                // Array of IAB content categories that describe the content.
+	VideoQuality       int       `json:"videoquality,omitempty"`       // Video quality per IAB's classification.
+	Context            int       `json:"context,omitempty"`            // Type of content (game, video, text, etc.).
+	ContentRating      string    `json:"contentrating,omitempty"`      // Content rating (e.g., MPAA).
+	UserRating         string    `json:"userrating,omitempty"`         // User rating of the content (e.g., number of stars, likes, etc.).
+	QAGMediaRating     int       `json:"qagmediarating,omitempty"`     // Media rating per QAG guidelines.
+	Keywords           string    `json:"keywords,omitempty"`           // Comma separated list of keywords describing the content.
+	LiveStream         int       `json:"livestream,omitempty"`         // 0 = not live, 1 = content is live (e.g., stream, live blog).
+	SourceRelationship int       `json:"sourcerelationship,omitempty"` // 0 = indirect, 1 = direct.
+	Len                int       `json:"len,omitempty"`                // Length of content in seconds; appropriate for video or audio.
+	Language           string    `json:"language,omitempty"`           // Content language using ISO-639-1-alpha-2.
+	Embeddable         int       `json:"embeddable,omitempty"`         // Indicator of whether or not the content is embeddable (e.g., an embeddable video player), where 0 = no, 1 = yes.
+	Ext                Extension `json:"ext,omitempty"`
 }

--- a/device.go
+++ b/device.go
@@ -1,38 +1,36 @@
 package openrtb
 
-import "encoding/json"
-
 // The "device" object provides information pertaining to the device including its hardware,
 // platform, location, and carrier. This device can refer to a mobile handset, a desktop computer,
 // set top box or other digital device.
 type Device struct {
-	DNT        int             `json:"dnt,omitempty"` // "1": Do not track
-	LMT        int             `json:"lmt,omitempty"` // "1": Limit Ad Tracking
-	UA         string          `json:"ua,omitempty"`  // User agent
-	IP         string          `json:"ip,omitempty"`  // IPv4
-	Geo        *Geo            `json:"geo,omitempty"`
-	IDSHA1     string          `json:"didsha1,omitempty"`  // SHA1 hashed device ID
-	IDMD5      string          `json:"didmd5,omitempty"`   // MD5 hashed device ID
-	PIDSHA1    string          `json:"dpidsha1,omitempty"` // SHA1 hashed platform device ID
-	PIDMD5     string          `json:"dpidmd5,omitempty"`  // MD5 hashed platform device ID
-	MacSHA1    string          `json:"macsha1,omitempty"`  // SHA1 hashed device ID; IMEI when available, else MEID or ESN
-	MacMD5     string          `json:"macmd5,omitempty"`   // MD5 hashed device ID; IMEI when available, else MEID or ESN
-	IPv6       string          `json:"ipv6,omitempty"`     // IPv6
-	Carrier    string          `json:"carrier,omitempty"`  // Carrier or ISP derived from the IP address
-	Language   string          `json:"language,omitempty"` // Browser language
-	Make       string          `json:"make,omitempty"`     // Device make
-	Model      string          `json:"model,omitempty"`    // Device model
-	OS         string          `json:"os,omitempty"`       // Device OS
-	OSVer      string          `json:"osv,omitempty"`      // Device OS version
-	JS         int             `json:"js,omitempty"`       // Javascript status ("0": Disabled, "1": Enabled)
-	ConnType   int             `json:"connectiontype,omitempty"`
-	DeviceType int             `json:"devicetype,omitempty"`
-	FlashVer   string          `json:"flashver,omitempty"` // Flash version
-	IFA        string          `json:"ifa,omitempty"`      // Native identifier for advertisers
-	Ext        json.RawMessage `json:"ext,omitempty"`
-	H          int             `json:"h,omitempty"`       // Physical height of the screen in pixels.
-	W          int             `json:"w,omitempty"`       // Physical width of the screen in pixels.
-	PPI        int             `json:"ppi,omitempty"`     // Screen size as pixels per linear inch.
-	PxRatio    float64         `json:"pxratio,omitempty"` // The ratio of physical pixels to device independent pixels.
-	HwVer      string          `json:"hwv,omitempty"`     // Hardware version of the device (e.g., "5S" for iPhone 5S).
+	DNT        int       `json:"dnt,omitempty"` // "1": Do not track
+	LMT        int       `json:"lmt,omitempty"` // "1": Limit Ad Tracking
+	UA         string    `json:"ua,omitempty"`  // User agent
+	IP         string    `json:"ip,omitempty"`  // IPv4
+	Geo        *Geo      `json:"geo,omitempty"`
+	IDSHA1     string    `json:"didsha1,omitempty"`  // SHA1 hashed device ID
+	IDMD5      string    `json:"didmd5,omitempty"`   // MD5 hashed device ID
+	PIDSHA1    string    `json:"dpidsha1,omitempty"` // SHA1 hashed platform device ID
+	PIDMD5     string    `json:"dpidmd5,omitempty"`  // MD5 hashed platform device ID
+	MacSHA1    string    `json:"macsha1,omitempty"`  // SHA1 hashed device ID; IMEI when available, else MEID or ESN
+	MacMD5     string    `json:"macmd5,omitempty"`   // MD5 hashed device ID; IMEI when available, else MEID or ESN
+	IPv6       string    `json:"ipv6,omitempty"`     // IPv6
+	Carrier    string    `json:"carrier,omitempty"`  // Carrier or ISP derived from the IP address
+	Language   string    `json:"language,omitempty"` // Browser language
+	Make       string    `json:"make,omitempty"`     // Device make
+	Model      string    `json:"model,omitempty"`    // Device model
+	OS         string    `json:"os,omitempty"`       // Device OS
+	OSVer      string    `json:"osv,omitempty"`      // Device OS version
+	JS         int       `json:"js,omitempty"`       // Javascript status ("0": Disabled, "1": Enabled)
+	ConnType   int       `json:"connectiontype,omitempty"`
+	DeviceType int       `json:"devicetype,omitempty"`
+	FlashVer   string    `json:"flashver,omitempty"` // Flash version
+	IFA        string    `json:"ifa,omitempty"`      // Native identifier for advertisers
+	Ext        Extension `json:"ext,omitempty"`
+	H          int       `json:"h,omitempty"`       // Physical height of the screen in pixels.
+	W          int       `json:"w,omitempty"`       // Physical width of the screen in pixels.
+	PPI        int       `json:"ppi,omitempty"`     // Screen size as pixels per linear inch.
+	PxRatio    float64   `json:"pxratio,omitempty"` // The ratio of physical pixels to device independent pixels.
+	HwVer      string    `json:"hwv,omitempty"`     // Hardware version of the device (e.g., "5S" for iPhone 5S).
 }

--- a/extension.go
+++ b/extension.go
@@ -1,0 +1,23 @@
+package openrtb
+
+import "errors"
+
+// Extension is a raw encoded JSON value.
+// It implements Marshaler and Unmarshaler, defined in encoding/json package,
+// works similarly to Extension,
+// but does not need to be used as pointer for proper JSON marshaling.
+type Extension []byte
+
+// MarshalJSON returns e as the JSON encoding of e.
+func (e Extension) MarshalJSON() ([]byte, error) {
+	return e, nil
+}
+
+// UnmarshalJSON sets *e to a copy of data.
+func (e *Extension) UnmarshalJSON(data []byte) error {
+	if e == nil {
+		return errors.New("openrtb.Extension: UnmarshalJSON on nil pointer")
+	}
+	*e = append((*e)[0:0], data...)
+	return nil
+}

--- a/extension_test.go
+++ b/extension_test.go
@@ -1,0 +1,29 @@
+package openrtb
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Extension", func() {
+	var _ json.Marshaler = (Extension)(nil)
+	var _ json.Unmarshaler = (*Extension)(nil)
+
+	It("should marshal JSON", func() {
+		subject := Extension(`{"foo":"bar"}`)
+
+		b, err := json.Marshal(subject)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(b).To(Equal([]byte(`{"foo":"bar"}`)))
+	})
+
+	It("should unmarshal JSON", func() {
+		subject := Extension([]byte{})
+
+		err := json.Unmarshal([]byte(`{"foo":"bar"}`), &subject)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(subject).To(Equal(Extension(`{"foo":"bar"}`)))
+	})
+})

--- a/impression.go
+++ b/impression.go
@@ -1,9 +1,6 @@
 package openrtb
 
-import (
-	"encoding/json"
-	"errors"
-)
+import "errors"
 
 // Validation errors
 var (
@@ -20,20 +17,20 @@ var (
 // The presence of Banner, Video, and/or Native objects
 // subordinate to the Imp object indicates the type of impression being offered.
 type Impression struct {
-	ID                string          `json:"id"` // A unique identifier for this impression
-	Banner            *Banner         `json:"banner,omitempty"`
-	Video             *Video          `json:"video,omitempty"`
-	Native            *Native         `json:"native,omitempty"`
-	DisplayManager    string          `json:"displaymanager,omitempty"`    // Name of ad mediation partner, SDK technology, etc
-	DisplayManagerVer string          `json:"displaymanagerver,omitempty"` // Version of the above
-	Instl             int             `json:"instl,omitempty"`             // Interstitial, Default: 0 ("1": Interstitial, "0": Something else)
-	TagID             string          `json:"tagid,omitempty"`             // IDentifier for specific ad placement or ad tag
-	BidFloor          float64         `json:"bidfloor,omitempty"`          // Bid floor for this impression in CPM
-	BidFloorCurrency  string          `json:"bidfloorcur,omitempty"`       // Currency of bid floor
-	Secure            int             `json:"secure,omitempty"`            // Flag to indicate whether the impression requires secure HTTPS URL creative assets and markup.
-	IFrameBuster      []string        `json:"iframebuster,omitempty"`      // Array of names for supportediframe busters.
-	Pmp               *Pmp            `json:"pmp,omitempty"`               // A reference to the PMP object containing any Deals eligible for the impression object.
-	Ext               json.RawMessage `json:"ext,omitempty"`
+	ID                string    `json:"id"` // A unique identifier for this impression
+	Banner            *Banner   `json:"banner,omitempty"`
+	Video             *Video    `json:"video,omitempty"`
+	Native            *Native   `json:"native,omitempty"`
+	DisplayManager    string    `json:"displaymanager,omitempty"`    // Name of ad mediation partner, SDK technology, etc
+	DisplayManagerVer string    `json:"displaymanagerver,omitempty"` // Version of the above
+	Instl             int       `json:"instl,omitempty"`             // Interstitial, Default: 0 ("1": Interstitial, "0": Something else)
+	TagID             string    `json:"tagid,omitempty"`             // IDentifier for specific ad placement or ad tag
+	BidFloor          float64   `json:"bidfloor,omitempty"`          // Bid floor for this impression in CPM
+	BidFloorCurrency  string    `json:"bidfloorcur,omitempty"`       // Currency of bid floor
+	Secure            int       `json:"secure,omitempty"`            // Flag to indicate whether the impression requires secure HTTPS URL creative assets and markup.
+	IFrameBuster      []string  `json:"iframebuster,omitempty"`      // Array of names for supportediframe busters.
+	Pmp               *Pmp      `json:"pmp,omitempty"`               // A reference to the PMP object containing any Deals eligible for the impression object.
+	Ext               Extension `json:"ext,omitempty"`
 }
 
 func (imp *Impression) assetCount() int {

--- a/inventory.go
+++ b/inventory.go
@@ -1,19 +1,17 @@
 package openrtb
 
-import "encoding/json"
-
 type Inventory struct {
-	ID            string          `json:"id,omitempty"` // ID on the exchange
-	Name          string          `json:"name,omitempty"`
-	Domain        string          `json:"domain,omitempty"`
-	Cat           []string        `json:"cat,omitempty"`          // Array of IAB content categories
-	SectionCat    []string        `json:"sectioncat,omitempty"`   // Array of IAB content categories for subsection
-	PageCat       []string        `json:"pagecat,omitempty"`      // Array of IAB content categories for page
-	PrivacyPolicy *int            `json:"pivacypolicy,omitempty"` // Default: 1 ("1": has a privacy policy)
-	Publisher     *Publisher      `json:"publisher,omitempty"`    // Details about the Publisher
-	Content       *Content        `json:"content,omitempty"`      // Details about the Content
-	Keywords      string          `json:"keywords,omitempty"`     // Comma separated list of keywords about the site.
-	Ext           json.RawMessage `json:"ext,omitempty"`
+	ID            string     `json:"id,omitempty"` // ID on the exchange
+	Name          string     `json:"name,omitempty"`
+	Domain        string     `json:"domain,omitempty"`
+	Cat           []string   `json:"cat,omitempty"`          // Array of IAB content categories
+	SectionCat    []string   `json:"sectioncat,omitempty"`   // Array of IAB content categories for subsection
+	PageCat       []string   `json:"pagecat,omitempty"`      // Array of IAB content categories for page
+	PrivacyPolicy *int       `json:"pivacypolicy,omitempty"` // Default: 1 ("1": has a privacy policy)
+	Publisher     *Publisher `json:"publisher,omitempty"`    // Details about the Publisher
+	Content       *Content   `json:"content,omitempty"`      // Details about the Content
+	Keywords      string     `json:"keywords,omitempty"`     // Comma separated list of keywords about the site.
+	Ext           Extension  `json:"ext,omitempty"`
 }
 
 // GetPrivacyPolicy returns the privacy policy value

--- a/native.go
+++ b/native.go
@@ -1,7 +1,5 @@
 package openrtb
 
-import "encoding/json"
-
 // This object represents a native type impression. Native ad units are intended to blend seamlessly into
 // the surrounding content (e.g., a sponsored Twitter or Facebook post). As such, the response must be
 // well-structured to afford the publisher fine-grained control over rendering.
@@ -10,9 +8,9 @@ import "encoding/json"
 // banner and/or video by also including as Imp subordinates the Banner and/or Video objects,
 // respectively. However, any given bid for the impression must conform to one of the offered types.
 type Native struct {
-	Request json.RawMessage `json:"request"`         // Request payload complying with the Native Ad Specification.
-	Ver     string          `json:"ver,omitempty"`   // Version of the Native Ad Specification to which request complies; highly recommended for efficient parsing.
-	API     []int           `json:"api,omitempty"`   // List of supported API frameworks for this impression.
-	BAttr   []int           `json:"battr,omitempty"` // Blocked creative attributes
-	Ext     json.RawMessage `json:"ext,omitempty"`
+	Request Extension `json:"request"`         // Request payload complying with the Native Ad Specification.
+	Ver     string    `json:"ver,omitempty"`   // Version of the Native Ad Specification to which request complies; highly recommended for efficient parsing.
+	API     []int     `json:"api,omitempty"`   // List of supported API frameworks for this impression.
+	BAttr   []int     `json:"battr,omitempty"` // Blocked creative attributes
+	Ext     Extension `json:"ext,omitempty"`
 }

--- a/native/request/asset.go
+++ b/native/request/asset.go
@@ -1,17 +1,17 @@
 package request
 
-import "encoding/json"
+import "github.com/bsm/openrtb"
 
 // The main container object for each asset requested or supported by Exchange
 // on behalf of the rendering client.  Only one of the {title,img,video,data}
 // objects should be present in each object.  The id is to be unique within the
 // AssetObject array so that the response can be aligned.
 type Asset struct {
-	ID       int             `json:"id"`                 // Unique asset ID, assigned by exchange
-	Required int             `json:"required,omitempty"` // Set to 1 if asset is required
-	Title    *Title          `json:"title,omitempty"`    // Title object for title assets
-	Image    *Image          `json:"img,omitempty"`      // Image object for image assets
-	Video    *Video          `json:"video,omitempty"`    // Video object for video assets
-	Data     *Data           `json:"data,omitempty"`     // Data object for brand name, description, ratings, prices etc.
-	Ext      json.RawMessage `json:"ext,omitempty"`
+	ID       int               `json:"id"`                 // Unique asset ID, assigned by exchange
+	Required int               `json:"required,omitempty"` // Set to 1 if asset is required
+	Title    *Title            `json:"title,omitempty"`    // Title object for title assets
+	Image    *Image            `json:"img,omitempty"`      // Image object for image assets
+	Video    *Video            `json:"video,omitempty"`    // Video object for video assets
+	Data     *Data             `json:"data,omitempty"`     // Data object for brand name, description, ratings, prices etc.
+	Ext      openrtb.Extension `json:"ext,omitempty"`
 }

--- a/native/request/data.go
+++ b/native/request/data.go
@@ -1,6 +1,6 @@
 package request
 
-import "encoding/json"
+import "github.com/bsm/openrtb"
 
 type DataTypeID int
 
@@ -21,7 +21,7 @@ const (
 )
 
 type Data struct {
-	TypeID DataTypeID      `json:"type"` // Type ID of the element supported by the publisher. The publisher can display this information in an appropriate format
-	Length int             `json:"len"`  // Maximum length of the text in the element’s response
-	Ext    json.RawMessage `json:"ext,omitempty"`
+	TypeID DataTypeID        `json:"type"` // Type ID of the element supported by the publisher. The publisher can display this information in an appropriate format
+	Length int               `json:"len"`  // Maximum length of the text in the element’s response
+	Ext    openrtb.Extension `json:"ext,omitempty"`
 }

--- a/native/request/image.go
+++ b/native/request/image.go
@@ -1,6 +1,6 @@
 package request
 
-import "encoding/json"
+import "github.com/bsm/openrtb"
 
 type ImageTypeID int
 
@@ -19,6 +19,6 @@ type Image struct {
 	HeightMin int `json:"hmin,omitempty"` // The minimum requested height of the image in pixels
 	// Either h/w or hmin/wmin should be transmitted. If only h/w is included, it
 	// should be considered an exact requirement
-	Mimes []string        `json:"mimes,omitempty"` // Whitelist of content MIME types supported
-	Ext   json.RawMessage `json:"ext,omitempty"`
+	Mimes []string          `json:"mimes,omitempty"` // Whitelist of content MIME types supported
+	Ext   openrtb.Extension `json:"ext,omitempty"`
 }

--- a/native/request/request.go
+++ b/native/request/request.go
@@ -1,6 +1,6 @@
 package request
 
-import "encoding/json"
+import "github.com/bsm/openrtb"
 
 type LayoutID int
 
@@ -66,14 +66,14 @@ const (
 // banner and/or video by also including as Imp subordinates the Banner and/or Video objects,
 // respectively. However, any given bid for the impression must conform to one of the offered types.
 type Request struct {
-	Ver              string           `json:"ver,omitempty"`            // Version of the Native Markup
-	LayoutID         LayoutID         `json:"layout,omitempty"`         // DEPRECATED The Layout ID of the native ad
-	AdUnitID         AdUnitID         `json:"adunit,omitempty"`         // DEPRECATED The Ad unit ID of the native ad
-	ContextTypeID    ContextTypeID    `json:"context,omitempty"`        // The context in which the ad appears
-	ContextSubTypeID ContextSubTypeID `json:"contextsubtype,omitempty"` // A more detailed context in which the ad appears
-	PlacementTypeID  PlacementTypeID  `json:"plcmttype,omitempty"`      // The design/format/layout of the ad unit being offered
-	PlacementCount   int              `json:"plcmtcnt,omitempty"`       // The number of identical placements in this Layout
-	Sequence         int              `json:"seq,omitempty"`            // 0 for the first ad, 1 for the second ad, and so on
-	Assets           []Asset          `json:"assets"`                   // An array of Asset Objects
-	Ext              json.RawMessage  `json:"ext,omitempty"`
+	Ver              string            `json:"ver,omitempty"`            // Version of the Native Markup
+	LayoutID         LayoutID          `json:"layout,omitempty"`         // DEPRECATED The Layout ID of the native ad
+	AdUnitID         AdUnitID          `json:"adunit,omitempty"`         // DEPRECATED The Ad unit ID of the native ad
+	ContextTypeID    ContextTypeID     `json:"context,omitempty"`        // The context in which the ad appears
+	ContextSubTypeID ContextSubTypeID  `json:"contextsubtype,omitempty"` // A more detailed context in which the ad appears
+	PlacementTypeID  PlacementTypeID   `json:"plcmttype,omitempty"`      // The design/format/layout of the ad unit being offered
+	PlacementCount   int               `json:"plcmtcnt,omitempty"`       // The number of identical placements in this Layout
+	Sequence         int               `json:"seq,omitempty"`            // 0 for the first ad, 1 for the second ad, and so on
+	Assets           []Asset           `json:"assets"`                   // An array of Asset Objects
+	Ext              openrtb.Extension `json:"ext,omitempty"`
 }

--- a/native/request/title.go
+++ b/native/request/title.go
@@ -1,8 +1,8 @@
 package request
 
-import "encoding/json"
+import "github.com/bsm/openrtb"
 
 type Title struct {
-	Length int             `json:"len"` // Maximum length of the text in the title element
-	Ext    json.RawMessage `json:"ext,omitempty"`
+	Length int               `json:"len"` // Maximum length of the text in the title element
+	Ext    openrtb.Extension `json:"ext,omitempty"`
 }

--- a/native/request/video.go
+++ b/native/request/video.go
@@ -1,12 +1,12 @@
 package request
 
-import "encoding/json"
+import "github.com/bsm/openrtb"
 
 // TODO unclear if its the same as imp.video https://github.com/openrtb/OpenRTB/issues/26
 type Video struct {
-	Mimes       []string        `json:"mimes,omitempty"`       // Whitelist of content MIME types supported
-	MinDuration int             `json:"minduration,omitempty"` // Minimum video ad duration in seconds
-	MaxDuration int             `json:"maxduration,omitempty"` // Maximum video ad duration in seconds
-	Protocols   []int           `json:"protocols,omitempty"`   // Video bid response protocols
-	Ext         json.RawMessage `json:"ext,omitempty"`
+	Mimes       []string          `json:"mimes,omitempty"`       // Whitelist of content MIME types supported
+	MinDuration int               `json:"minduration,omitempty"` // Minimum video ad duration in seconds
+	MaxDuration int               `json:"maxduration,omitempty"` // Maximum video ad duration in seconds
+	Protocols   []int             `json:"protocols,omitempty"`   // Video bid response protocols
+	Ext         openrtb.Extension `json:"ext,omitempty"`
 }

--- a/native/response/asset.go
+++ b/native/response/asset.go
@@ -1,6 +1,6 @@
 package response
 
-import "encoding/json"
+import "github.com/bsm/openrtb"
 
 // Corresponds to the Asset Object in the request. The main container object for
 // each asset requested or supported by Exchange on behalf of the rendering
@@ -9,12 +9,12 @@ import "encoding/json"
 // should be null/absent. The id is to be unique within the AssetObject array so
 // that the response can be aligned.
 type Asset struct {
-	ID       int             `json:"id"`                 // Unique asset ID, assigned by exchange, must match one of the asset IDs in request
-	Required int             `json:"required,omitempty"` // Set to 1 if asset is required
-	Title    *Title          `json:"title,omitempty"`    // Title object for title assets
-	Image    *Image          `json:"img,omitempty"`      // Image object for image assets
-	Video    *Video          `json:"video,omitempty"`    // Video object for video assets
-	Data     *Data           `json:"data,omitempty"`     // Data object for brand name, description, ratings, prices etc.
-	Link     *Link           `json:"link,omitempty"`     // Link object for call to actions. The link object applies if the asset item is activated (clicked)
-	Ext      json.RawMessage `json:"ext,omitempty"`
+	ID       int               `json:"id"`                 // Unique asset ID, assigned by exchange, must match one of the asset IDs in request
+	Required int               `json:"required,omitempty"` // Set to 1 if asset is required
+	Title    *Title            `json:"title,omitempty"`    // Title object for title assets
+	Image    *Image            `json:"img,omitempty"`      // Image object for image assets
+	Video    *Video            `json:"video,omitempty"`    // Video object for video assets
+	Data     *Data             `json:"data,omitempty"`     // Data object for brand name, description, ratings, prices etc.
+	Link     *Link             `json:"link,omitempty"`     // Link object for call to actions. The link object applies if the asset item is activated (clicked)
+	Ext      openrtb.Extension `json:"ext,omitempty"`
 }

--- a/native/response/data.go
+++ b/native/response/data.go
@@ -1,9 +1,9 @@
 package response
 
-import "encoding/json"
+import "github.com/bsm/openrtb"
 
 type Data struct {
-	Label string          `json:"label,omitempty"` // The optional formatted string name of the data type to be displayed
-	Value string          `json:"value"`           // The formatted string of data to be displayed. Can contain a formatted value such as “5 stars” or “$10” or “3.4 stars out of 5”
-	Ext   json.RawMessage `json:"ext,omitempty"`
+	Label string            `json:"label,omitempty"` // The optional formatted string name of the data type to be displayed
+	Value string            `json:"value"`           // The formatted string of data to be displayed. Can contain a formatted value such as “5 stars” or “$10” or “3.4 stars out of 5”
+	Ext   openrtb.Extension `json:"ext,omitempty"`
 }

--- a/native/response/image.go
+++ b/native/response/image.go
@@ -1,10 +1,10 @@
 package response
 
-import "encoding/json"
+import "github.com/bsm/openrtb"
 
 type Image struct {
-	URL    string          `json:"url,omitempty"` // URL of the image asset
-	Width  int             `json:"w,omitempty"`   // Width of the image in pixels
-	Height int             `json:"h,omitempty"`   // Height of the image in pixels
-	Ext    json.RawMessage `json:"ext,omitempty"`
+	URL    string            `json:"url,omitempty"` // URL of the image asset
+	Width  int               `json:"w,omitempty"`   // Width of the image in pixels
+	Height int               `json:"h,omitempty"`   // Height of the image in pixels
+	Ext    openrtb.Extension `json:"ext,omitempty"`
 }

--- a/native/response/link.go
+++ b/native/response/link.go
@@ -1,10 +1,10 @@
 package response
 
-import "encoding/json"
+import "github.com/bsm/openrtb"
 
 type Link struct {
-	URL           string          `json:"url"`                // Landing URL of the clickable link
-	ClickTrackers []string        `json:"clicktrackers"`      // List of third-party tracker URLs to be fired on click of the URL
-	FallbackURL   string          `json:"fallback,omitempty"` // Fallback URL for deeplink. To be used if the URL given in url is not supported by the device.
-	Ext           json.RawMessage `json:"ext,omitempty"`
+	URL           string            `json:"url"`                // Landing URL of the clickable link
+	ClickTrackers []string          `json:"clicktrackers"`      // List of third-party tracker URLs to be fired on click of the URL
+	FallbackURL   string            `json:"fallback,omitempty"` // Fallback URL for deeplink. To be used if the URL given in url is not supported by the device.
+	Ext           openrtb.Extension `json:"ext,omitempty"`
 }

--- a/native/response/response.go
+++ b/native/response/response.go
@@ -1,13 +1,13 @@
 package response
 
-import "encoding/json"
+import "github.com/bsm/openrtb"
 
 // The native object is the top level JSON object which identifies a native response
 type Response struct {
-	Ver         string          `json:"ver,omitempty"`         // Version of the Native Markup
-	Assets      []Asset         `json:"assets"`                // An array of Asset Objects
-	Link        Link            `json:"link"`                  // Destination Link. This is default link object for the ad
-	ImpTrackers []string        `json:"imptrackers,omitempty"` // Array of impression tracking URLs, expected to return a 1x1 image or 204 response
-	JSTracker   string          `json:"jstracker,omitempty"`   // Optional JavaScript impression tracker. This is a valid HTML, Javascript is already wrapped in <script> tags. It should be executed at impression time where it can be supported
-	Ext         json.RawMessage `json:"ext,omitempty"`
+	Ver         string            `json:"ver,omitempty"`         // Version of the Native Markup
+	Assets      []Asset           `json:"assets"`                // An array of Asset Objects
+	Link        Link              `json:"link"`                  // Destination Link. This is default link object for the ad
+	ImpTrackers []string          `json:"imptrackers,omitempty"` // Array of impression tracking URLs, expected to return a 1x1 image or 204 response
+	JSTracker   string            `json:"jstracker,omitempty"`   // Optional JavaScript impression tracker. This is a valid HTML, Javascript is already wrapped in <script> tags. It should be executed at impression time where it can be supported
+	Ext         openrtb.Extension `json:"ext,omitempty"`
 }

--- a/native/response/title.go
+++ b/native/response/title.go
@@ -1,8 +1,8 @@
 package response
 
-import "encoding/json"
+import "github.com/bsm/openrtb"
 
 type Title struct {
-	Text string          `json:"text"` // The text associated with the text element
-	Ext  json.RawMessage `json:"ext,omitempty"`
+	Text string            `json:"text"` // The text associated with the text element
+	Ext  openrtb.Extension `json:"ext,omitempty"`
 }

--- a/native_test.go
+++ b/native_test.go
@@ -1,8 +1,6 @@
 package openrtb
 
 import (
-	"encoding/json"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -17,7 +15,7 @@ var _ = Describe("Native", func() {
 
 	It("should parse correctly", func() {
 		Expect(subject).To(Equal(&Native{
-			Request: json.RawMessage(`"PAYLOAD"`),
+			Request: Extension(`"PAYLOAD"`),
 			Ver:     "2",
 		}))
 	})

--- a/openrtb.go
+++ b/openrtb.go
@@ -1,7 +1,5 @@
 package openrtb
 
-import "encoding/json"
-
 // 5.2 Banner Ad Types
 const (
 	BannerTypeXHTMLText int = iota + 1
@@ -169,11 +167,11 @@ const (
 
 // Abstract third-party
 type ThirdParty struct {
-	ID     string          `json:"id,omitempty"`
-	Name   string          `json:"name,omitempty"`
-	Cat    []string        `json:"cat,omitempty"` // Array of IAB content categories
-	Domain string          `json:"domain,omitempty"`
-	Ext    json.RawMessage `json:"ext,omitempty"`
+	ID     string    `json:"id,omitempty"`
+	Name   string    `json:"name,omitempty"`
+	Cat    []string  `json:"cat,omitempty"` // Array of IAB content categories
+	Domain string    `json:"domain,omitempty"`
+	Ext    Extension `json:"ext,omitempty"`
 }
 
 // The publisher object itself and all of its parameters are optional, so default values are not
@@ -191,17 +189,17 @@ type Producer ThirdParty
 // (such as IP geo lookup), or by user registration information (for example provided to a publisher
 // through a user registration).
 type Geo struct {
-	Lat           float64         `json:"lat,omitempty"`           // Latitude from -90 to 90
-	Lon           float64         `json:"lon,omitempty"`           // Longitude from -180 to 180
-	Country       string          `json:"country,omitempty"`       // Country using ISO 3166-1 Alpha 3
-	Region        string          `json:"region,omitempty"`        // Region using ISO 3166-2
-	RegionFIPS104 string          `json:"regionFIPS104,omitempty"` // Region of a country using FIPS 10-4
-	Metro         string          `json:"metro,omitempty"`
-	City          string          `json:"city,omitempty"`
-	Zip           string          `json:"zip,omitempty"`
-	Type          int             `json:"type,omitempty"`      // Indicate the source of the geo data
-	UTCOffset     int             `json:"utcoffset,omitempty"` // Local time as the number +/- of minutes from UTC
-	Ext           json.RawMessage `json:"ext,omitempty"`
+	Lat           float64   `json:"lat,omitempty"`           // Latitude from -90 to 90
+	Lon           float64   `json:"lon,omitempty"`           // Longitude from -180 to 180
+	Country       string    `json:"country,omitempty"`       // Country using ISO 3166-1 Alpha 3
+	Region        string    `json:"region,omitempty"`        // Region using ISO 3166-2
+	RegionFIPS104 string    `json:"regionFIPS104,omitempty"` // Region of a country using FIPS 10-4
+	Metro         string    `json:"metro,omitempty"`
+	City          string    `json:"city,omitempty"`
+	Zip           string    `json:"zip,omitempty"`
+	Type          int       `json:"type,omitempty"`      // Indicate the source of the geo data
+	UTCOffset     int       `json:"utcoffset,omitempty"` // Local time as the number +/- of minutes from UTC
+	Ext           Extension `json:"ext,omitempty"`
 }
 
 // This object contains information known or derived about the human user of the device (i.e., the
@@ -209,16 +207,16 @@ type Geo struct {
 // privacy policies. However, this user ID must be stable long enough to serve reasonably as the basis for
 // frequency capping and retargeting.
 type User struct {
-	ID         string          `json:"id,omitempty"`         // Unique consumer ID of this user on the exchange
-	BuyerID    string          `json:"buyerid,omitempty"`    // Buyer-specific ID for the user as mapped by the exchange for the buyer. At least one of buyeruid/buyerid or id is recommended. Valid for OpenRTB 2.3.
-	BuyerUID   string          `json:"buyeruid,omitempty"`   // Buyer-specific ID for the user as mapped by the exchange for the buyer. Same as BuyerID but valid for OpenRTB 2.2.
-	YOB        int             `json:"yob,omitempty"`        // Year of birth as a 4-digit integer.
-	Gender     string          `json:"gender,omitempty"`     // Gender ("M": male, "F" female, "O" Other)
-	Keywords   string          `json:"keywords,omitempty"`   // Comma separated list of keywords, interests, or intent
-	CustomData string          `json:"customdata,omitempty"` // Optional feature to pass bidder data that was set in the exchange's cookie. The string must be in base85 cookie safe characters and be in any format. Proper JSON encoding must be used to include "escaped" quotation marks.
-	Geo        *Geo            `json:"geo,omitempty"`
-	Data       []Data          `json:"data,omitempty"`
-	Ext        json.RawMessage `json:"ext,omitempty"`
+	ID         string    `json:"id,omitempty"`         // Unique consumer ID of this user on the exchange
+	BuyerID    string    `json:"buyerid,omitempty"`    // Buyer-specific ID for the user as mapped by the exchange for the buyer. At least one of buyeruid/buyerid or id is recommended. Valid for OpenRTB 2.3.
+	BuyerUID   string    `json:"buyeruid,omitempty"`   // Buyer-specific ID for the user as mapped by the exchange for the buyer. Same as BuyerID but valid for OpenRTB 2.2.
+	YOB        int       `json:"yob,omitempty"`        // Year of birth as a 4-digit integer.
+	Gender     string    `json:"gender,omitempty"`     // Gender ("M": male, "F" female, "O" Other)
+	Keywords   string    `json:"keywords,omitempty"`   // Comma separated list of keywords, interests, or intent
+	CustomData string    `json:"customdata,omitempty"` // Optional feature to pass bidder data that was set in the exchange's cookie. The string must be in base85 cookie safe characters and be in any format. Proper JSON encoding must be used to include "escaped" quotation marks.
+	Geo        *Geo      `json:"geo,omitempty"`
+	Data       []Data    `json:"data,omitempty"`
+	Ext        Extension `json:"ext,omitempty"`
 }
 
 // The data and segment objects together allow additional data about the user to be specified. This data
@@ -226,26 +224,26 @@ type User struct {
 // the id field. A bid request can mix data objects from multiple providers. The specific data providers in
 // use should be published by the exchange a priori to its bidders.
 type Data struct {
-	ID      string          `json:"id,omitempty"`
-	Name    string          `json:"name,omitempty"`
-	Segment []Segment       `json:"segment,omitempty"`
-	Ext     json.RawMessage `json:"ext,omitempty"`
+	ID      string    `json:"id,omitempty"`
+	Name    string    `json:"name,omitempty"`
+	Segment []Segment `json:"segment,omitempty"`
+	Ext     Extension `json:"ext,omitempty"`
 }
 
 // Segment objects are essentially key-value pairs that convey specific units of data about the user. The
 // parent Data object is a collection of such values from a given data provider. The specific segment
 // names and value options must be published by the exchange a priori to its bidders.
 type Segment struct {
-	ID    string          `json:"id,omitempty"`
-	Name  string          `json:"name,omitempty"`
-	Value string          `json:"value,omitempty"`
-	Ext   json.RawMessage `json:"ext,omitempty"`
+	ID    string    `json:"id,omitempty"`
+	Name  string    `json:"name,omitempty"`
+	Value string    `json:"value,omitempty"`
+	Ext   Extension `json:"ext,omitempty"`
 }
 
 // This object contains any legal, governmental, or industry regulations that apply to the request. The
 // coppa flag signals whether or not the request falls under the United States Federal Trade Commission's
 // regulations for the United States Children's Online Privacy Protection Act ("COPPA").
 type Regulations struct {
-	Coppa int             `json:"coppa,omitempty"` // Flag indicating if this request is subject to the COPPA regulations established by the USA FTC, where 0 = no, 1 = yes.
-	Ext   json.RawMessage `json:"ext,omitempty"`
+	Coppa int       `json:"coppa,omitempty"` // Flag indicating if this request is subject to the COPPA regulations established by the USA FTC, where 0 = no, 1 = yes.
+	Ext   Extension `json:"ext,omitempty"`
 }

--- a/pmp.go
+++ b/pmp.go
@@ -4,20 +4,20 @@ import "encoding/json"
 
 // Private Marketplace Object
 type Pmp struct {
-	Private int             `json:"private_auction,omitempty"`
-	Deals   []Deal          `json:"deals,omitempty"`
-	Ext     json.RawMessage `json:"ext,omitempty"`
+	Private int       `json:"private_auction,omitempty"`
+	Deals   []Deal    `json:"deals,omitempty"`
+	Ext     Extension `json:"ext,omitempty"`
 }
 
 // PMP Deal
 type Deal struct {
-	ID               string          `json:"id,omitempty"` // Unique deal ID
-	BidFloor         float64         `json:"bidfloor,omitempty"`
-	BidFloorCurrency string          `json:"bidfloorcur,omitempty"` // Currency of bid floor
-	WSeat            []string        `json:"wseat,omitempty"`       // Array of buyer seats allowed to bid on this Direct Deal.
-	WAdvDomain       []string        `json:"wadomain,omitempty"`    // Array of advertiser domains allowed to bid on this Direct Deal
-	AuctionType      int             `json:"at,omitempty"`          // Optional override of the overall auction type of the bid request, where 1 = First Price, 2 = Second Price Plus, 3 = the value passed in bidfloor is the agreed upon deal price. Additional auction types can be defined by the exchange.
-	Ext              json.RawMessage `json:"ext,omitempty"`
+	ID               string    `json:"id,omitempty"` // Unique deal ID
+	BidFloor         float64   `json:"bidfloor,omitempty"`
+	BidFloorCurrency string    `json:"bidfloorcur,omitempty"` // Currency of bid floor
+	WSeat            []string  `json:"wseat,omitempty"`       // Array of buyer seats allowed to bid on this Direct Deal.
+	WAdvDomain       []string  `json:"wadomain,omitempty"`    // Array of advertiser domains allowed to bid on this Direct Deal
+	AuctionType      int       `json:"at,omitempty"`          // Optional override of the overall auction type of the bid request, where 1 = First Price, 2 = Second Price Plus, 3 = the value passed in bidfloor is the agreed upon deal price. Additional auction types can be defined by the exchange.
+	Ext              Extension `json:"ext,omitempty"`
 
 	Seats []string `json:"seats,omitempty"` // DEPRECATED: kept for backwards compatibility
 	Type  int      `json:"type,omitempty"`  // DEPRECATED: kept for backwards compatibility

--- a/seatbid.go
+++ b/seatbid.go
@@ -1,9 +1,6 @@
 package openrtb
 
-import (
-	"encoding/json"
-	"errors"
-)
+import "errors"
 
 // At least one of Bid is required.
 // A bid response can contain multiple "seatbid” objects, each on behalf of a different bidder seat.
@@ -12,10 +9,10 @@ import (
 // Group attribute can be used to specify if a seat is willing to accept any impressions that it can win (default) or if it is
 // only interested in winning any if it can win them all (i.e., all or nothing).
 type SeatBid struct {
-	Bid   []Bid           `json:"bid"`             // Array of bid objects; each realtes to an imp, if exchange supported can have many bid objects.
-	Seat  string          `json:"seat,omitempty"`  // ID of the bidder seat optional string ID of the bidder seat on whose behalf this bid is made.
-	Group int             `json:"group,omitempty"` // '1' means impression must be won-lost as a group; default is '0'.
-	Ext   json.RawMessage `json:"ext,omitempty"`
+	Bid   []Bid     `json:"bid"`             // Array of bid objects; each realtes to an imp, if exchange supported can have many bid objects.
+	Seat  string    `json:"seat,omitempty"`  // ID of the bidder seat optional string ID of the bidder seat on whose behalf this bid is made.
+	Group int       `json:"group,omitempty"` // '1' means impression must be won-lost as a group; default is '0'.
+	Ext   Extension `json:"ext,omitempty"`
 }
 
 // Validation errors

--- a/video.go
+++ b/video.go
@@ -17,28 +17,28 @@ var (
 // The "video" object must be included directly in the impression object if the impression offered
 // for auction is an in-stream video ad opportunity.
 type Video struct {
-	Mimes          []string        `json:"mimes,omitempty"`          // Content MIME types supported.
-	MinDuration    int             `json:"minduration,omitempty"`    // Minimum video ad duration in seconds
-	MaxDuration    int             `json:"maxduration,omitempty"`    // Maximum video ad duration in seconds
-	Protocol       int             `json:"protocol,omitempty"`       // Video bid response protocols
-	Protocols      []int           `json:"protocols,omitempty"`      // Video bid response protocols
-	W              int             `json:"w,omitempty"`              // Width of the player in pixels
-	H              int             `json:"h,omitempty"`              // Height of the player in pixels
-	StartDelay     int             `json:"startdelay,omitempty"`     // Indicates the start delay in seconds
-	Linearity      int             `json:"linearity,omitempty"`      // Indicates whether the ad impression is linear or non-linear
-	Sequence       int             `json:"sequence,omitempty"`       // Default: 1
-	BAttr          []int           `json:"battr,omitempty"`          // Blocked creative attributes
-	MaxExtended    int             `json:"maxextended,omitempty"`    // Maximum extended video ad duration
-	MinBitrate     int             `json:"minbitrate,omitempty"`     // Minimum bit rate in Kbps
-	MaxBitrate     int             `json:"maxbitrate,omitempty"`     // Maximum bit rate in Kbps
-	BoxingAllowed  *int            `json:"boxingallowed,omitempty"`  // If exchange publisher has rules preventing letter boxing
-	PlaybackMethod []int           `json:"playbackmethod,omitempty"` // List of allowed playback methods
-	Delivery       []int           `json:"delivery,omitempty"`       // List of supported delivery methods
-	Pos            int             `json:"pos,omitempty"`            // Ad Position
-	CompanionAd    []Banner        `json:"companionad,omitempty"`
-	Api            []int           `json:"api,omitempty"` // List of supported API frameworks
-	CompanionType  []int           `json:"companiontype,omitempty"`
-	Ext            json.RawMessage `json:"ext,omitempty"`
+	Mimes          []string  `json:"mimes,omitempty"`          // Content MIME types supported.
+	MinDuration    int       `json:"minduration,omitempty"`    // Minimum video ad duration in seconds
+	MaxDuration    int       `json:"maxduration,omitempty"`    // Maximum video ad duration in seconds
+	Protocol       int       `json:"protocol,omitempty"`       // Video bid response protocols
+	Protocols      []int     `json:"protocols,omitempty"`      // Video bid response protocols
+	W              int       `json:"w,omitempty"`              // Width of the player in pixels
+	H              int       `json:"h,omitempty"`              // Height of the player in pixels
+	StartDelay     int       `json:"startdelay,omitempty"`     // Indicates the start delay in seconds
+	Linearity      int       `json:"linearity,omitempty"`      // Indicates whether the ad impression is linear or non-linear
+	Sequence       int       `json:"sequence,omitempty"`       // Default: 1
+	BAttr          []int     `json:"battr,omitempty"`          // Blocked creative attributes
+	MaxExtended    int       `json:"maxextended,omitempty"`    // Maximum extended video ad duration
+	MinBitrate     int       `json:"minbitrate,omitempty"`     // Minimum bit rate in Kbps
+	MaxBitrate     int       `json:"maxbitrate,omitempty"`     // Maximum bit rate in Kbps
+	BoxingAllowed  *int      `json:"boxingallowed,omitempty"`  // If exchange publisher has rules preventing letter boxing
+	PlaybackMethod []int     `json:"playbackmethod,omitempty"` // List of allowed playback methods
+	Delivery       []int     `json:"delivery,omitempty"`       // List of supported delivery methods
+	Pos            int       `json:"pos,omitempty"`            // Ad Position
+	CompanionAd    []Banner  `json:"companionad,omitempty"`
+	Api            []int     `json:"api,omitempty"` // List of supported API frameworks
+	CompanionType  []int     `json:"companiontype,omitempty"`
+	Ext            Extension `json:"ext,omitempty"`
 }
 
 type jsonVideo Video


### PR DESCRIPTION
Because `json.RawMessage` needs to be used as pointer for proper marshaling: https://groups.google.com/forum/#!topic/Golang-Nuts/38ShOlhxAYY

I don't like importing `github.com/bsm/openrtb` in `native/**/*.go` much, but "root" `openrtb` package seems to be the most appropriate place to put `type Extension`.