### PR TITLE
Removed check for empty assets to support another formats like onclick with openrtb format

### DIFF
--- a/bidrequest_test.go
+++ b/bidrequest_test.go
@@ -67,7 +67,6 @@ var _ = Describe("BidRequest", func() {
 		Expect((&BidRequest{}).Validate()).To(Equal(ErrInvalidReqNoID))
 		Expect((&BidRequest{ID: "A"}).Validate()).To(Equal(ErrInvalidReqNoImps))
 		Expect((&BidRequest{ID: "A", Imp: []Impression{{ID: "1"}}, Site: &Site{}, App: &App{}}).Validate()).To(Equal(ErrInvalidReqMultiInv))
-		Expect((&BidRequest{ID: "A", Imp: []Impression{{ID: "1"}}}).Validate()).To(Equal(ErrInvalidImpNoAssets))
 
 		Expect((&BidRequest{ID: "A", Imp: []Impression{{ID: "1", Banner: &Banner{}}}}).Validate()).NotTo(HaveOccurred())
 		Expect((&BidRequest{ID: "A", Imp: []Impression{{ID: "1", Banner: &Banner{}}}, Site: &Site{}}).Validate()).NotTo(HaveOccurred())

--- a/impression.go
+++ b/impression.go
@@ -5,7 +5,6 @@ import "errors"
 // Validation errors
 var (
 	ErrInvalidImpNoID        = errors.New("openrtb: impression ID missing")
-	ErrInvalidImpNoAssets    = errors.New("openrtb: impression has no assets")       // neither Banner, nor Video, nor Native
 	ErrInvalidImpMultiAssets = errors.New("openrtb: impression has multiple assets") // at least two out of Banner, Video, Native
 )
 
@@ -55,9 +54,7 @@ func (imp *Impression) Validate() error {
 		return ErrInvalidImpNoID
 	}
 
-	if count := imp.assetCount(); count == 0 {
-		return ErrInvalidImpNoAssets
-	} else if count > 1 {
+	if count := imp.assetCount(); count > 1 {
 		return ErrInvalidImpMultiAssets
 	}
 

--- a/impression_test.go
+++ b/impression_test.go
@@ -36,7 +36,6 @@ var _ = Describe("Impression", func() {
 
 	It("should validate", func() {
 		Expect((&Impression{}).Validate()).To(Equal(ErrInvalidImpNoID))
-		Expect((&Impression{ID: "IMPID"}).Validate()).To(Equal(ErrInvalidImpNoAssets))
 		Expect((&Impression{ID: "IMPID", Banner: &Banner{}, Video: &Video{}}).Validate()).To(Equal(ErrInvalidImpMultiAssets))
 		Expect((&Impression{ID: "IMPID", Banner: &Banner{}}).Validate()).NotTo(HaveOccurred())
 	})


### PR DESCRIPTION
Hello. Please view this pull request.

We are using this library in our project and have a trouble with incomprehensible behavior.
As you can see in documentation for OpenRTB 2.4 http://www.iab.com/wp-content/uploads/2016/01/OpenRTB-API-Specification-Version-2-4-DRAFT.pdf objects banner, video and native not required.

So our project is onclick advertisment and not need to have all of this formats in our requests. But now library not working (throw "openrtb: impression has no assets") if no one of this elements presents.

This PR removes this check