### PR TITLE
Use json.Number instead of string for some fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Go OpenRTB v2.x
 
-[![Build Status](https://travis-ci.org/bsm/openrtb.svg?branch=master)](https://travis-ci.org/bsm/openrtb)
+[![Build Status](https://travis-ci.org/Upliner/openrtb.svg?branch=master)](https://travis-ci.org/bsm/openrtb)
 
 OpenRTB implementation for Go
 

--- a/bid.go
+++ b/bid.go
@@ -1,6 +1,9 @@
 package openrtb
 
-import "errors"
+import (
+	"encoding/json"
+	"errors"
+)
 
 // Validation errors
 var (
@@ -16,33 +19,33 @@ var (
 // Cid can be used to block ads that were previously identified as inappropriate.
 // Substitution macros may allow a bidder to use a static notice URL for all of its bids.
 type Bid struct {
-	ID             string    `json:"id"`
-	ImpID          string    `json:"impid"`                    // Required string ID of the impression object to which this bid applies.
-	Price          float64   `json:"price"`                    // Bid price in CPM. Suggests using integer math for accounting to avoid rounding errors.
-	AdID           string    `json:"adid,omitempty"`           // References the ad to be served if the bid wins.
-	NURL           string    `json:"nurl,omitempty"`           // Win notice URL.
-	BURL           string    `json:"burl,omitempty"`           // Billing notice URL.
-	LURL           string    `json:"lurl,omitempty"`           // Loss notice URL.
-	AdMarkup       string    `json:"adm,omitempty"`            // Actual ad markup. XHTML if a response to a banner object, or VAST XML if a response to a video object.
-	AdvDomain      []string  `json:"adomain,omitempty"`        // Advertiser’s primary or top-level domain for advertiser checking; or multiple if imp rotating.
-	Bundle         string    `json:"bundle,omitempty"`         // A platform-specific application identifier intended to be unique to the app and independent of the exchange.
-	IURL           string    `json:"iurl,omitempty"`           // Sample image URL.
-	CampaignID     string    `json:"cid,omitempty"`            // Campaign ID that appears with the Ad markup.
-	CreativeID     string    `json:"crid,omitempty"`           // Creative ID for reporting content issues or defects. This could also be used as a reference to a creative ID that is posted with an exchange.
-	Tactic         string    `json:"tactic,omitempty"`         // Tactic ID to enable buyers to label bids for reporting to the exchange the tactic through which their bid was submitted.
-	Cat            []string  `json:"cat,omitempty"`            // IAB content categories of the creative. Refer to List 5.1
-	Attr           []int     `json:"attr,omitempty"`           // Array of creative attributes.
-	API            int       `json:"api,omitempty"`            // API required by the markup if applicable
-	Protocol       int       `json:"protocol,omitempty"`       // Video response protocol of the markup if applicable
-	QAGMediaRating int       `json:"qagmediarating,omitempty"` // Creative media rating per IQG guidelines.
-	Language       string    `json:"language,omitempty"`       // Language of the creative using ISO-639-1-alpha-2.
-	DealID         string    `json:"dealid,omitempty"`         // DealID extension of private marketplace deals
-	H              int       `json:"h,omitempty"`              // Height of the ad in pixels.
-	W              int       `json:"w,omitempty"`              // Width of the ad in pixels.
-	WRatio         int       `json:"wratio,omitempty"`         // Relative width of the creative when expressing size as a ratio.
-	HRatio         int       `json:"hratio,omitempty"`         // Relative height of the creative when expressing size as a ratio.
-	Exp            int       `json:"exp,omitempty"`            // Advisory as to the number of seconds the bidder is willing to wait between the auction and the actual impression.
-	Ext            Extension `json:"ext,omitempty"`
+	ID             string      `json:"id"`
+	ImpID          string      `json:"impid"`                    // Required string ID of the impression object to which this bid applies.
+	Price          float64     `json:"price"`                    // Bid price in CPM. Suggests using integer math for accounting to avoid rounding errors.
+	AdID           string      `json:"adid,omitempty"`           // References the ad to be served if the bid wins.
+	NURL           string      `json:"nurl,omitempty"`           // Win notice URL.
+	BURL           string      `json:"burl,omitempty"`           // Billing notice URL.
+	LURL           string      `json:"lurl,omitempty"`           // Loss notice URL.
+	AdMarkup       string      `json:"adm,omitempty"`            // Actual ad markup. XHTML if a response to a banner object, or VAST XML if a response to a video object.
+	AdvDomain      []string    `json:"adomain,omitempty"`        // Advertiser’s primary or top-level domain for advertiser checking; or multiple if imp rotating.
+	Bundle         string      `json:"bundle,omitempty"`         // A platform-specific application identifier intended to be unique to the app and independent of the exchange.
+	IURL           string      `json:"iurl,omitempty"`           // Sample image URL.
+	CampaignID     json.Number `json:"cid,omitempty"`            // Campaign ID that appears with the Ad markup.
+	CreativeID     string      `json:"crid,omitempty"`           // Creative ID for reporting content issues or defects. This could also be used as a reference to a creative ID that is posted with an exchange.
+	Tactic         string      `json:"tactic,omitempty"`         // Tactic ID to enable buyers to label bids for reporting to the exchange the tactic through which their bid was submitted.
+	Cat            []string    `json:"cat,omitempty"`            // IAB content categories of the creative. Refer to List 5.1
+	Attr           []int       `json:"attr,omitempty"`           // Array of creative attributes.
+	API            int         `json:"api,omitempty"`            // API required by the markup if applicable
+	Protocol       int         `json:"protocol,omitempty"`       // Video response protocol of the markup if applicable
+	QAGMediaRating int         `json:"qagmediarating,omitempty"` // Creative media rating per IQG guidelines.
+	Language       string      `json:"language,omitempty"`       // Language of the creative using ISO-639-1-alpha-2.
+	DealID         string      `json:"dealid,omitempty"`         // DealID extension of private marketplace deals
+	H              int         `json:"h,omitempty"`              // Height of the ad in pixels.
+	W              int         `json:"w,omitempty"`              // Width of the ad in pixels.
+	WRatio         int         `json:"wratio,omitempty"`         // Relative width of the creative when expressing size as a ratio.
+	HRatio         int         `json:"hratio,omitempty"`         // Relative height of the creative when expressing size as a ratio.
+	Exp            int         `json:"exp,omitempty"`            // Advisory as to the number of seconds the bidder is willing to wait between the auction and the actual impression.
+	Ext            Extension   `json:"ext,omitempty"`
 }
 
 // Validate required attributes

--- a/native/request/asset.go
+++ b/native/request/asset.go
@@ -1,6 +1,6 @@
 package request
 
-import "github.com/bsm/openrtb"
+import "github.com/Upliner/openrtb"
 
 // The main container object for each asset requested or supported by Exchange
 // on behalf of the rendering client.  Only one of the {title,img,video,data}

--- a/native/request/data.go
+++ b/native/request/data.go
@@ -1,6 +1,6 @@
 package request
 
-import "github.com/bsm/openrtb"
+import "github.com/Upliner/openrtb"
 
 type DataTypeID int
 

--- a/native/request/image.go
+++ b/native/request/image.go
@@ -1,6 +1,6 @@
 package request
 
-import "github.com/bsm/openrtb"
+import "github.com/Upliner/openrtb"
 
 type ImageTypeID int
 

--- a/native/request/request.go
+++ b/native/request/request.go
@@ -1,6 +1,6 @@
 package request
 
-import "github.com/bsm/openrtb"
+import "github.com/Upliner/openrtb"
 
 type LayoutID int
 

--- a/native/request/request_test.go
+++ b/native/request/request_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/bsm/openrtb"
+	"github.com/Upliner/openrtb"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/native/request/title.go
+++ b/native/request/title.go
@@ -1,6 +1,6 @@
 package request
 
-import "github.com/bsm/openrtb"
+import "github.com/Upliner/openrtb"
 
 type Title struct {
 	Length int               `json:"len"` // Maximum length of the text in the title element

--- a/native/request/video.go
+++ b/native/request/video.go
@@ -1,6 +1,6 @@
 package request
 
-import "github.com/bsm/openrtb"
+import "github.com/Upliner/openrtb"
 
 // TODO unclear if its the same as imp.video https://github.com/openrtb/OpenRTB/issues/26
 type Video struct {

--- a/native/response/asset.go
+++ b/native/response/asset.go
@@ -1,6 +1,6 @@
 package response
 
-import "github.com/bsm/openrtb"
+import "github.com/Upliner/openrtb"
 
 // Corresponds to the Asset Object in the request. The main container object for
 // each asset requested or supported by Exchange on behalf of the rendering

--- a/native/response/data.go
+++ b/native/response/data.go
@@ -1,6 +1,6 @@
 package response
 
-import "github.com/bsm/openrtb"
+import "github.com/Upliner/openrtb"
 
 type Data struct {
 	Label string            `json:"label,omitempty"` // The optional formatted string name of the data type to be displayed

--- a/native/response/image.go
+++ b/native/response/image.go
@@ -1,6 +1,6 @@
 package response
 
-import "github.com/bsm/openrtb"
+import "github.com/Upliner/openrtb"
 
 type Image struct {
 	URL    string            `json:"url,omitempty"` // URL of the image asset

--- a/native/response/link.go
+++ b/native/response/link.go
@@ -1,6 +1,6 @@
 package response
 
-import "github.com/bsm/openrtb"
+import "github.com/Upliner/openrtb"
 
 type Link struct {
 	URL           string            `json:"url"`                // Landing URL of the clickable link

--- a/native/response/response.go
+++ b/native/response/response.go
@@ -1,10 +1,13 @@
 package response
 
-import "github.com/bsm/openrtb"
+import (
+	"encoding/json"
+	"github.com/bsm/openrtb"
+)
 
 // The native object is the top level JSON object which identifies a native response
 type Response struct {
-	Ver         string            `json:"ver,omitempty"`         // Version of the Native Markup
+	Ver         json.Number       `json:"ver,omitempty"`         // Version of the Native Markup
 	Assets      []Asset           `json:"assets"`                // An array of Asset Objects
 	Link        Link              `json:"link"`                  // Destination Link. This is default link object for the ad
 	ImpTrackers []string          `json:"imptrackers,omitempty"` // Array of impression tracking URLs, expected to return a 1x1 image or 204 response

--- a/native/response/response.go
+++ b/native/response/response.go
@@ -2,7 +2,7 @@ package response
 
 import (
 	"encoding/json"
-	"github.com/bsm/openrtb"
+	"github.com/Upliner/openrtb"
 )
 
 // The native object is the top level JSON object which identifies a native response

--- a/native/response/title.go
+++ b/native/response/title.go
@@ -1,6 +1,6 @@
 package response
 
-import "github.com/bsm/openrtb"
+import "github.com/Upliner/openrtb"
 
 type Title struct {
 	Text string            `json:"text"` // The text associated with the text element


### PR DESCRIPTION
Some DSP providers don't quote some fields and they cannot be unmarshaled as strings. json.Number supports both strings and numbers so it won't break existing functionality.