### PR TITLE
fix StringOrNumber for empty strings

### DIFF
--- a/numbers.go
+++ b/numbers.go
@@ -36,7 +36,7 @@ type StringOrNumber string
 
 // UnmarshalJSON implements json.Unmarshaler
 func (n *StringOrNumber) UnmarshalJSON(data []byte) error {
-	if len(data) > 2 && data[0] == '"' && data[len(data)-1] == '"' {
+	if len(data) >= 2 && data[0] == '"' && data[len(data)-1] == '"' {
 		var v string
 		if err := json.Unmarshal(data, &v); err != nil {
 			return err

--- a/numbers_test.go
+++ b/numbers_test.go
@@ -44,11 +44,24 @@ var _ = Describe("StringOrNumber", func() {
 		Expect(n).To(Equal(StringOrNumber("33")))
 	})
 
+	It("should decode strings", func() {
+		var n StringOrNumber
+		Expect(json.Unmarshal([]byte(`""`), &n)).To(Succeed())
+		Expect(n).To(Equal(StringOrNumber("")))
+	})
+
 	It("should encode to strings", func() {
 		var n StringOrNumber = "33"
 		bin, err := json.Marshal(n)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(bin)).To(Equal(`"33"`))
+	})
+
+	It("should encode to strings", func() {
+		var n StringOrNumber = ""
+		bin, err := json.Marshal(n)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(bin)).To(Equal(`""`))
 	})
 
 })


### PR DESCRIPTION
I have following response from vanilla-rtb and it seems that in your Bid.cid it's not string but StringOrNumber . It looks to me as it's valid case to have empty strings for cid or crid.
Example is below. 

{"id":"","seatbid":[{"bid":[{"id":"1b9b3fa3-ecd2-4c99-8ded-0fd40c2de1bb","impid":"1","price":0.000786,"adid":"329","nurl":"","adm":"<script>alert(\" ad 329!\");</script>","adomain":[],"iurl":"","cid":"","crid":"","attr":[],"dealid":"","w":300,"h":100}],"seat":"","group":0}],"bidid":"6c666344-6bc3-4e6c-864d-25d850b36c16","cur":"RUB","customdata":"","nbr":0}
