### PR TITLE
Change type on Content.Context from int to NumberOrString

### DIFF
--- a/content.go
+++ b/content.go
@@ -6,30 +6,30 @@ package openrtb
 // knowledge of the page where the content is running, as a result of the syndication method. For
 // example might be a video impression embedded in an iframe on an unknown web property or device.
 type Content struct {
-	ID                 string    `json:"id,omitempty"`                 // ID uniquely identifying the content.
-	Episode            int       `json:"episode,omitempty"`            // Episode number (typically applies to video content).
-	Title              string    `json:"title,omitempty"`              // Content title.
-	Series             string    `json:"series,omitempty"`             // Content series.
-	Season             string    `json:"season,omitempty"`             // Content season.
-	Artist             string    `json:"artist,omitempty"`             // Artist credited with the content.
-	Genre              string    `json:"genre,omitempty"`              // Genre that best describes the content
-	Album              string    `json:"album,omitempty"`              // Album to which the content belongs; typically for audio.
-	ISRC               string    `json:"isrc,omitempty"`               // International Standard Recording Code conforming to ISO - 3901.
-	Producer           *Producer `json:"producer,omitempty"`           // The producer.
-	URL                string    `json:"url,omitempty"`                // URL of the content, for buy-side contextualization or review.
-	Cat                []string  `json:"cat,omitempty"`                // Array of IAB content categories that describe the content.
-	ProdQuality        int       `json:"prodq,omitempty"`              // Production quality per IAB's classification.
-	VideoQuality       int       `json:"videoquality,omitempty"`       // Video quality per IAB's classification.
-	Context            int       `json:"context,omitempty"`            // Type of content (game, video, text, etc.).
-	ContentRating      string    `json:"contentrating,omitempty"`      // Content rating (e.g., MPAA).
-	UserRating         string    `json:"userrating,omitempty"`         // User rating of the content (e.g., number of stars, likes, etc.).
-	QAGMediaRating     int       `json:"qagmediarating,omitempty"`     // Media rating per QAG guidelines.
-	Keywords           string    `json:"keywords,omitempty"`           // Comma separated list of keywords describing the content.
-	LiveStream         int       `json:"livestream,omitempty"`         // 0 = not live, 1 = content is live (e.g., stream, live blog).
-	SourceRelationship int       `json:"sourcerelationship,omitempty"` // 0 = indirect, 1 = direct.
-	Len                int       `json:"len,omitempty"`                // Length of content in seconds; appropriate for video or audio.
-	Language           string    `json:"language,omitempty"`           // Content language using ISO-639-1-alpha-2.
-	Embeddable         int       `json:"embeddable,omitempty"`         // Indicator of whether or not the content is embeddable (e.g., an embeddable video player), where 0 = no, 1 = yes.
-	Data               []Data    `json:"data,omitempty"`               // Additional content data.
-	Ext                Extension `json:"ext,omitempty"`
+	ID                 string         `json:"id,omitempty"`                 // ID uniquely identifying the content.
+	Episode            int            `json:"episode,omitempty"`            // Episode number (typically applies to video content).
+	Title              string         `json:"title,omitempty"`              // Content title.
+	Series             string         `json:"series,omitempty"`             // Content series.
+	Season             string         `json:"season,omitempty"`             // Content season.
+	Artist             string         `json:"artist,omitempty"`             // Artist credited with the content.
+	Genre              string         `json:"genre,omitempty"`              // Genre that best describes the content
+	Album              string         `json:"album,omitempty"`              // Album to which the content belongs; typically for audio.
+	ISRC               string         `json:"isrc,omitempty"`               // International Standard Recording Code conforming to ISO - 3901.
+	Producer           *Producer      `json:"producer,omitempty"`           // The producer.
+	URL                string         `json:"url,omitempty"`                // URL of the content, for buy-side contextualization or review.
+	Cat                []string       `json:"cat,omitempty"`                // Array of IAB content categories that describe the content.
+	ProdQuality        int            `json:"prodq,omitempty"`              // Production quality per IAB's classification.
+	VideoQuality       int            `json:"videoquality,omitempty"`       // Video quality per IAB's classification.
+	Context            NumberOrString `json:"context,omitempty"`            // Type of content (game, video, text, etc.).
+	ContentRating      string         `json:"contentrating,omitempty"`      // Content rating (e.g., MPAA).
+	UserRating         string         `json:"userrating,omitempty"`         // User rating of the content (e.g., number of stars, likes, etc.).
+	QAGMediaRating     int            `json:"qagmediarating,omitempty"`     // Media rating per QAG guidelines.
+	Keywords           string         `json:"keywords,omitempty"`           // Comma separated list of keywords describing the content.
+	LiveStream         int            `json:"livestream,omitempty"`         // 0 = not live, 1 = content is live (e.g., stream, live blog).
+	SourceRelationship int            `json:"sourcerelationship,omitempty"` // 0 = indirect, 1 = direct.
+	Len                int            `json:"len,omitempty"`                // Length of content in seconds; appropriate for video or audio.
+	Language           string         `json:"language,omitempty"`           // Content language using ISO-639-1-alpha-2.
+	Embeddable         int            `json:"embeddable,omitempty"`         // Indicator of whether or not the content is embeddable (e.g., an embeddable video player), where 0 = no, 1 = yes.
+	Data               []Data         `json:"data,omitempty"`               // Additional content data.
+	Ext                Extension      `json:"ext,omitempty"`
 }

--- a/content_test.go
+++ b/content_test.go
@@ -26,3 +26,32 @@ var _ = Describe("Content", func() {
 	})
 
 })
+
+var _ = Describe("QuotedContent", func() {
+	var subject *Content
+
+	BeforeEach(func() {
+		err := fixture("content.quoted", &subject)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should parse correctly", func() {
+		Expect(subject).To(Equal(&Content{
+			Keywords:           "Orwell, 1984",
+			UserRating:         "3",
+			Episode:            1,
+			Title:              "This is the video title",
+			URL:                "http://cdnp.tremormedia.com/video/1984.flv",
+			LiveStream:         0,
+			ContentRating:      "G",
+			Len:                129,
+			Series:             "book reading",
+			VideoQuality:       2,
+			Context:            1,
+			Season:             "1",
+			SourceRelationship: 0,
+			ID:                 "eb9f13ede5fd225333971523f6042f9d",
+		}))
+	})
+
+})

--- a/testdata/content.quoted.json
+++ b/testdata/content.quoted.json
@@ -1,0 +1,16 @@
+{
+  "keywords": "Orwell, 1984",
+  "userrating": "3",
+  "episode": 1,
+  "title": "This is the video title",
+  "url": "http://cdnp.tremormedia.com/video/1984.flv",
+  "livestream": 0,
+  "contentrating": "G",
+  "len": 129,
+  "series": "book reading",
+  "videoquality": 2,
+  "context": "1",
+  "season": "1",
+  "sourcerelationship": 0,
+  "id": "eb9f13ede5fd225333971523f6042f9d"
+}


### PR DESCRIPTION
Some SSPs permit Content object's Context field to be a quoted integer. This PR changes the type of that field from `int` to `NumberOrString` to parse bid requests where this is the case.

Example bid request, in this case from Telaria --

```{
  "app": {
    "privacypolicy": 0,
    "storeurl": "",
    "domain": "demo.tremormedia.com",
    "cat": [
      "IAB1-1"
    ],
    "name": "MadHive Tremor TAM InApp Supply",
    "publisher": {
      "name": "Tremor TAM TEST SUPPLY Publisher",
      "id": "1b79c05b-39c4-43a5-9ad8-f66a2e9fad3d"
    },
    "id": "TAMTESTseat-ujyfg",
    "content": {
      "keywords": "Orwell, 1984",
      "userrating": "3",
      "episode": 1,
      "title": "This is the video title",
      "url": "http://cdnp.tremormedia.com/video/1984.flv",
      "livestream": 0,
      "contentrating": "G",
      "len": 129,
      "series": "book reading",
      "videoquality": 2,
      "context": "1",
      "season": "1",
      "sourcerelationship": 0,
      "id": "eb9f13ede5fd225333971523f6042f9d"
    }
  },
  "ext": {
    "pchain": "1a4e959a1b50034a:TAMTESTseatk0vfp"
  },
  "cur": [
    "USD"
  ],
  "at": 2,
  "tmax": 250,
  "regs": {
    "ext": {
      "gdpr": 0
    },
    "coppa": 0
  },
  "id": "2b88dcfa-c73b-48b7-b2ff-2c1c31ea0715",
  "imp": [
    {
      "pmp": {
        "deals": [
          {
            "at": 2,
            "id": "MADHIVE-IOA-TESTDEAL-09122018"
          }
        ],
        "private_auction": 1
      },
      "tagid": "TAMTESTseat-k0vfp",
      "id": "1",
      "video": {
        "boxingallowed": 1,
        "maxextended": 0,
        "linearity": 1,
        "maxduration": 30,
        "pos": 1,
        "w": 720,
        "h": 480,
        "startdelay": 0,
        "protocols": [
          2,
          5
        ],
        "minduration": 0,
        "mimes": [
          "video/mp4"
        ]
      },
      "secure": 0,
      "instl": 0
    }
  ],
  "device": {
    "geo": {
      "zip": "11221",
      "country": "USA",
      "metro": "501",
      "lon": -73.9268,
      "region": "NY",
      "type": 2,
      "lat": 40.692
    },
    "osv": "10.13",
    "os": "os x",
    "ip": "69.112.224.192",
    "language": "en",
    "dnt": 0,
    "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36",
    "devicetype": 2
  },
  "user": {
    "id": "59c428834985497c9c624fcf2c0adc28"
  }
}```