### PR TITLE
Add omitempty to Native Ad Response Link struct

### DIFF
--- a/native/response/link.go
+++ b/native/response/link.go
@@ -3,8 +3,8 @@ package response
 import "github.com/bsm/openrtb"
 
 type Link struct {
-	URL           string            `json:"url"`                // Landing URL of the clickable link
-	ClickTrackers []string          `json:"clicktrackers"`      // List of third-party tracker URLs to be fired on click of the URL
-	FallbackURL   string            `json:"fallback,omitempty"` // Fallback URL for deeplink. To be used if the URL given in url is not supported by the device.
+	URL           string            `json:"url"`                     // Landing URL of the clickable link
+	ClickTrackers []string          `json:"clicktrackers,omitempty"` // List of third-party tracker URLs to be fired on click of the URL
+	FallbackURL   string            `json:"fallback,omitempty"`      // Fallback URL for deeplink. To be used if the URL given in url is not supported by the device.
 	Ext           openrtb.Extension `json:"ext,omitempty"`
 }


### PR DESCRIPTION
`clicktrackers` field is optional according to the IAB spec and should be omitted if empty.