### PR TITLE
Not validate "video.minduration" and "maxduration"

### DIFF
--- a/video.go
+++ b/video.go
@@ -7,11 +7,9 @@ import (
 
 // Validation errors
 var (
-	ErrInvalidVideoNoMIMEs       = errors.New("openrtb: video has no mimes")
-	ErrInvalidVideoNoLinearity   = errors.New("openrtb: video linearity missing")
-	ErrInvalidVideoNoMinDuration = errors.New("openrtb: video min-duration missing")
-	ErrInvalidVideoNoMaxDuration = errors.New("openrtb: video max-duration missing")
-	ErrInvalidVideoNoProtocols   = errors.New("openrtb: video protocols missing")
+	ErrInvalidVideoNoMIMEs     = errors.New("openrtb: video has no mimes")
+	ErrInvalidVideoNoLinearity = errors.New("openrtb: video linearity missing")
+	ErrInvalidVideoNoProtocols = errors.New("openrtb: video protocols missing")
 )
 
 // Video object must be included directly in the impression object if the impression offered
@@ -53,10 +51,6 @@ func (v *Video) Validate() error {
 		return ErrInvalidVideoNoMIMEs
 	} else if v.Linearity == 0 {
 		return ErrInvalidVideoNoLinearity
-	} else if v.MinDuration == 0 {
-		return ErrInvalidVideoNoMinDuration
-	} else if v.MaxDuration == 0 {
-		return ErrInvalidVideoNoMaxDuration
 	} else if v.Protocol == 0 && len(v.Protocols) == 0 {
 		return ErrInvalidVideoNoProtocols
 	}

--- a/video_test.go
+++ b/video_test.go
@@ -52,15 +52,6 @@ var _ = Describe("Video", func() {
 			MIMEs: []string{"video/mp4"},
 		}).Validate()).To(Equal(ErrInvalidVideoNoLinearity))
 		Expect((&Video{
-			Linearity: VideoLinearityNonLinear,
-			MIMEs:     []string{"video/mp4"},
-		}).Validate()).To(Equal(ErrInvalidVideoNoMinDuration))
-		Expect((&Video{
-			MinDuration: 1,
-			Linearity:   VideoLinearityNonLinear,
-			MIMEs:       []string{"video/mp4"},
-		}).Validate()).To(Equal(ErrInvalidVideoNoMaxDuration))
-		Expect((&Video{
 			MinDuration: 1,
 			MaxDuration: 1,
 			Linearity:   VideoLinearityNonLinear,


### PR DESCRIPTION
`video.minduration` and `video.maxduration` are recommended attributes, but are not required.
<img width="635" alt="スクリーンショット 2019-11-01 17 30 18" src="https://user-images.githubusercontent.com/5907247/68012866-a3053200-fcce-11e9-8918-9aaee83f5361.png">

They should be excluded from validation.
For instance, the Mopub video bid request sample is currently invalid.
https://developers.mopub.com/dsps/integration/openrtb/#616-rewarded-video-request