### PR TITLE
feat: change request.imp.native.request type to string

### DIFF
--- a/native.go
+++ b/native.go
@@ -10,7 +10,7 @@ import "encoding/json"
 // banner and/or video by also including as Imp subordinates the Banner and/or Video objects,
 // respectively. However, any given bid for the impression must conform to one of the offered types.
 type Native struct {
-	Request      json.RawMessage     `json:"request"`         // Request payload complying with the Native Ad Specification.
+	Request      string              `json:"request"`         // Request payload complying with the Native Ad Specification.
 	Version      string              `json:"ver,omitempty"`   // Version of the Native Ad Specification to which request complies; highly recommended for efficient parsing.
 	APIs         []APIFramework      `json:"api,omitempty"`   // List of supported API frameworks for this impression.
 	BlockedAttrs []CreativeAttribute `json:"battr,omitempty"` // Blocked creative attributes


### PR DESCRIPTION
OpenRTBの仕様に合わせて`request.imp.native.request`  をstringにします
https://www.iab.com/wp-content/uploads/2016/01/OpenRTB-API-Specification-Version-2-4-DRAFT.pdf
