### PR TITLE
Format ratio added

### DIFF
--- a/openrtb.go
+++ b/openrtb.go
@@ -832,8 +832,12 @@ type Regulations struct {
 
 // Format object represents an allowed size (i.e., height and width combination) for a banner impression.
 // These are typically used in an array for an impression where multiple sizes are permitted.
+// It is recommended that either the w/h pair or the wratio/hratio/wmin set (i.e., for Flex Ads) be specified.
 type Format struct {
-	Width  int             `json:"w,omitempty"` // Width in device independent pixels (DIPS).
-	Height int             `json:"h,omitempty"` //Height in device independent pixels (DIPS).
-	Ext    json.RawMessage `json:"ext,omitempty"`
+	Width       int             `json:"w,omitempty"`       // Width in device independent pixels (DIPS).
+	Height      int             `json:"h,omitempty"`       // Height in device independent pixels (DIPS).
+	WidthRatio  int             `json:"wratio,omitempty"`  // Relative width when expressing size as a ratio.
+	HeightRatio int             `json:"hration,omitempty"` // Relative height when expressing size as a ratio.
+	WidthMin    int             `json:"wmin,omitempty"`    // The minimum width in device independent pixels (DIPS) at which the ad will be displayed the size is expressed as a ratio.
+	Ext         json.RawMessage `json:"ext,omitempty"`
 }


### PR DESCRIPTION
Hi, 

I added 3 missing fields in the [Format structure described](https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf#%5B%7B%22num%22%3A86%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C69%2C261%2C0%5D) in the OpenRTB documentation:
- WidthRatio,
- HeightRatio,
- WidthMin