### PR TITLE
Add open rtb 2.6 features in Bid Response (seatbid.bid)

### DIFF
--- a/bid.go
+++ b/bid.go
@@ -20,39 +20,41 @@ var (
 // Cid can be used to block ads that were previously identified as inappropriate.
 // Substitution macros may allow a bidder to use a static notice URL for all of its bids.
 type Bid struct {
-	ID               string              `json:"id"`
-	ImpID            string              `json:"impid"`                    // Required string ID of the impression object to which this bid applies.
-	Price            float64             `json:"price"`                    // Bid price in CPM. Suggests using integer math for accounting to avoid rounding errors.
-	AdID             string              `json:"adid,omitempty"`           // References the ad to be served if the bid wins.
-	NoticeURL        string              `json:"nurl,omitempty"`           // Win notice URL.
-	BillingURL       string              `json:"burl,omitempty"`           // Billing notice URL.
-	LossURL          string              `json:"lurl,omitempty"`           // Loss notice URL.
-	AdMarkup         string              `json:"adm,omitempty"`            // Actual ad markup. XHTML if a response to a banner object, or VAST XML if a response to a video object.
-	AdvDomains       []string            `json:"adomain,omitempty"`        // Advertiser’s primary or top-level domain for advertiser checking; or multiple if imp rotating.
-	Bundle           string              `json:"bundle,omitempty"`         // A platform-specific application identifier intended to be unique to the app and independent of the exchange.
-	ImageURL         string              `json:"iurl,omitempty"`           // Sample image URL.
-	CampaignID       StringOrNumber      `json:"cid,omitempty"`            // Campaign ID that appears with the Ad markup.
-	CreativeID       string              `json:"crid,omitempty"`           // Creative ID for reporting content issues or defects. This could also be used as a reference to a creative ID that is posted with an exchange.
-	Tactic           string              `json:"tactic,omitempty"`         // Tactic ID to enable buyers to label bids for reporting to the exchange the tactic through which their bid was submitted.
-	Categories       []ContentCategory   `json:"cat,omitempty"`            // IAB content categories of the creative. Refer to List 5.1
-	Attrs            []CreativeAttribute `json:"attr,omitempty"`           // Array of creative attributes.
-	API              APIFramework        `json:"api,omitempty"`            // API required by the markup if applicable, NOTE: for ORTB ver <= 2.5 APIFramework supported is 1 to 6.
-	APIS             APIFramework        `json:"apis,omitempty"`           // APIS required by the markup if applicable.
-	Protocol         Protocol            `json:"protocol,omitempty"`       // Video response protocol of the markup if applicable
-	MediaRating      IQGRating           `json:"qagmediarating,omitempty"` // Creative media rating per IQG guidelines.
-	Language         string              `json:"language,omitempty"`       // Language of the creative using ISO-639-1-alpha-2.
-	DealID           string              `json:"dealid,omitempty"`         // DealID extension of private marketplace deals
-	Width            int                 `json:"w,omitempty"`              // Width of the ad in pixels.
-	Height           int                 `json:"h,omitempty"`              // Height of the ad in pixels.
-	WidthRatio       int                 `json:"wratio,omitempty"`         // Relative width of the creative when expressing size as a ratio.
-	HeightRatio      int                 `json:"hratio,omitempty"`         // Relative height of the creative when expressing size as a ratio.
-	LangB            string              `json:"langb,omitempty"`          // Language of the creative using IETF BCP 47. Only one of language or langb should be present.
-	Duration         int                 `json:"dur,omitempty"`            // Duration of the video or audio creative in seconds.
-	MarkupType       MarkupType          `json:"mtype,omitempty"`          // Creative markup so that it can properly be associated.
-	SlotInPod        SlotPositionInPod   `json:"slotinpod,omitempty"`      // Indicates that the bid response is only eligible for a specific position.
-	CategoryTaxonomy CategoryTaxonomy    `json:"cattax,omitempty"`         // Defines the taxonomy in use.
-	Exp              int                 `json:"exp,omitempty"`            // Advisory as to the number of seconds the bidder is willing to wait between the auction and the actual impression.
-	Ext              json.RawMessage     `json:"ext,omitempty"`
+	ID          string              `json:"id"`
+	ImpID       string              `json:"impid"`                    // Required string ID of the impression object to which this bid applies.
+	Price       float64             `json:"price"`                    // Bid price in CPM. Suggests using integer math for accounting to avoid rounding errors.
+	AdID        string              `json:"adid,omitempty"`           // References the ad to be served if the bid wins.
+	NoticeURL   string              `json:"nurl,omitempty"`           // Win notice URL.
+	BillingURL  string              `json:"burl,omitempty"`           // Billing notice URL.
+	LossURL     string              `json:"lurl,omitempty"`           // Loss notice URL.
+	AdMarkup    string              `json:"adm,omitempty"`            // Actual ad markup. XHTML if a response to a banner object, or VAST XML if a response to a video object.
+	AdvDomains  []string            `json:"adomain,omitempty"`        // Advertiser’s primary or top-level domain for advertiser checking; or multiple if imp rotating.
+	Bundle      string              `json:"bundle,omitempty"`         // A platform-specific application identifier intended to be unique to the app and independent of the exchange.
+	ImageURL    string              `json:"iurl,omitempty"`           // Sample image URL.
+	CampaignID  StringOrNumber      `json:"cid,omitempty"`            // Campaign ID that appears with the Ad markup.
+	CreativeID  string              `json:"crid,omitempty"`           // Creative ID for reporting content issues or defects. This could also be used as a reference to a creative ID that is posted with an exchange.
+	Tactic      string              `json:"tactic,omitempty"`         // Tactic ID to enable buyers to label bids for reporting to the exchange the tactic through which their bid was submitted.
+	Categories  []ContentCategory   `json:"cat,omitempty"`            // IAB content categories of the creative. Refer to List 5.1
+	Attrs       []CreativeAttribute `json:"attr,omitempty"`           // Array of creative attributes.
+	API         APIFramework        `json:"api,omitempty"`            // API required by the markup if applicable, NOTE: for ORTB ver <= 2.5 APIFramework supported is 1 to 6.
+	Protocol    Protocol            `json:"protocol,omitempty"`       // Video response protocol of the markup if applicable
+	MediaRating IQGRating           `json:"qagmediarating,omitempty"` // Creative media rating per IQG guidelines.
+	Language    string              `json:"language,omitempty"`       // Language of the creative using ISO-639-1-alpha-2.
+	DealID      string              `json:"dealid,omitempty"`         // DealID extension of private marketplace deals
+	Width       int                 `json:"w,omitempty"`              // Width of the ad in pixels.
+	Height      int                 `json:"h,omitempty"`              // Height of the ad in pixels.
+	WidthRatio  int                 `json:"wratio,omitempty"`         // Relative width of the creative when expressing size as a ratio.
+	HeightRatio int                 `json:"hratio,omitempty"`         // Relative height of the creative when expressing size as a ratio.
+
+	APIS             APIFramework      `json:"apis,omitempty"`      // APIS required by the markup if applicable.
+	LangB            string            `json:"langb,omitempty"`     // Language of the creative using IETF BCP 47. Only one of language or langb should be present.
+	Duration         int               `json:"dur,omitempty"`       // Duration of the video or audio creative in seconds.
+	MarkupType       MarkupType        `json:"mtype,omitempty"`     // Creative markup so that it can properly be associated.
+	SlotInPod        SlotPositionInPod `json:"slotinpod,omitempty"` // Indicates that the bid response is only eligible for a specific position.
+	CategoryTaxonomy CategoryTaxonomy  `json:"cattax,omitempty"`    // Defines the taxonomy in use.
+
+	Exp int             `json:"exp,omitempty"` // Advisory as to the number of seconds the bidder is willing to wait between the auction and the actual impression.
+	Ext json.RawMessage `json:"ext,omitempty"`
 }
 
 // Validate required attributes

--- a/bid.go
+++ b/bid.go
@@ -20,33 +20,39 @@ var (
 // Cid can be used to block ads that were previously identified as inappropriate.
 // Substitution macros may allow a bidder to use a static notice URL for all of its bids.
 type Bid struct {
-	ID          string              `json:"id"`
-	ImpID       string              `json:"impid"`                    // Required string ID of the impression object to which this bid applies.
-	Price       float64             `json:"price"`                    // Bid price in CPM. Suggests using integer math for accounting to avoid rounding errors.
-	AdID        string              `json:"adid,omitempty"`           // References the ad to be served if the bid wins.
-	NoticeURL   string              `json:"nurl,omitempty"`           // Win notice URL.
-	BillingURL  string              `json:"burl,omitempty"`           // Billing notice URL.
-	LossURL     string              `json:"lurl,omitempty"`           // Loss notice URL.
-	AdMarkup    string              `json:"adm,omitempty"`            // Actual ad markup. XHTML if a response to a banner object, or VAST XML if a response to a video object.
-	AdvDomains  []string            `json:"adomain,omitempty"`        // Advertiser’s primary or top-level domain for advertiser checking; or multiple if imp rotating.
-	Bundle      string              `json:"bundle,omitempty"`         // A platform-specific application identifier intended to be unique to the app and independent of the exchange.
-	ImageURL    string              `json:"iurl,omitempty"`           // Sample image URL.
-	CampaignID  StringOrNumber      `json:"cid,omitempty"`            // Campaign ID that appears with the Ad markup.
-	CreativeID  string              `json:"crid,omitempty"`           // Creative ID for reporting content issues or defects. This could also be used as a reference to a creative ID that is posted with an exchange.
-	Tactic      string              `json:"tactic,omitempty"`         // Tactic ID to enable buyers to label bids for reporting to the exchange the tactic through which their bid was submitted.
-	Categories  []ContentCategory   `json:"cat,omitempty"`            // IAB content categories of the creative. Refer to List 5.1
-	Attrs       []CreativeAttribute `json:"attr,omitempty"`           // Array of creative attributes.
-	API         APIFramework        `json:"api,omitempty"`            // API required by the markup if applicable
-	Protocol    Protocol            `json:"protocol,omitempty"`       // Video response protocol of the markup if applicable
-	MediaRating IQGRating           `json:"qagmediarating,omitempty"` // Creative media rating per IQG guidelines.
-	Language    string              `json:"language,omitempty"`       // Language of the creative using ISO-639-1-alpha-2.
-	DealID      string              `json:"dealid,omitempty"`         // DealID extension of private marketplace deals
-	Width       int                 `json:"w,omitempty"`              // Width of the ad in pixels.
-	Height      int                 `json:"h,omitempty"`              // Height of the ad in pixels.
-	WidthRatio  int                 `json:"wratio,omitempty"`         // Relative width of the creative when expressing size as a ratio.
-	HeightRatio int                 `json:"hratio,omitempty"`         // Relative height of the creative when expressing size as a ratio.
-	Exp         int                 `json:"exp,omitempty"`            // Advisory as to the number of seconds the bidder is willing to wait between the auction and the actual impression.
-	Ext         json.RawMessage     `json:"ext,omitempty"`
+	ID               string              `json:"id"`
+	ImpID            string              `json:"impid"`                    // Required string ID of the impression object to which this bid applies.
+	Price            float64             `json:"price"`                    // Bid price in CPM. Suggests using integer math for accounting to avoid rounding errors.
+	AdID             string              `json:"adid,omitempty"`           // References the ad to be served if the bid wins.
+	NoticeURL        string              `json:"nurl,omitempty"`           // Win notice URL.
+	BillingURL       string              `json:"burl,omitempty"`           // Billing notice URL.
+	LossURL          string              `json:"lurl,omitempty"`           // Loss notice URL.
+	AdMarkup         string              `json:"adm,omitempty"`            // Actual ad markup. XHTML if a response to a banner object, or VAST XML if a response to a video object.
+	AdvDomains       []string            `json:"adomain,omitempty"`        // Advertiser’s primary or top-level domain for advertiser checking; or multiple if imp rotating.
+	Bundle           string              `json:"bundle,omitempty"`         // A platform-specific application identifier intended to be unique to the app and independent of the exchange.
+	ImageURL         string              `json:"iurl,omitempty"`           // Sample image URL.
+	CampaignID       StringOrNumber      `json:"cid,omitempty"`            // Campaign ID that appears with the Ad markup.
+	CreativeID       string              `json:"crid,omitempty"`           // Creative ID for reporting content issues or defects. This could also be used as a reference to a creative ID that is posted with an exchange.
+	Tactic           string              `json:"tactic,omitempty"`         // Tactic ID to enable buyers to label bids for reporting to the exchange the tactic through which their bid was submitted.
+	Categories       []ContentCategory   `json:"cat,omitempty"`            // IAB content categories of the creative. Refer to List 5.1
+	Attrs            []CreativeAttribute `json:"attr,omitempty"`           // Array of creative attributes.
+	API              APIFramework        `json:"api,omitempty"`            // API required by the markup if applicable, NOTE: for ORTB ver <= 2.5 APIFramework supported is 1 to 6.
+	APIS             APIFramework        `json:"apis,omitempty"`           // APIS required by the markup if applicable.
+	Protocol         Protocol            `json:"protocol,omitempty"`       // Video response protocol of the markup if applicable
+	MediaRating      IQGRating           `json:"qagmediarating,omitempty"` // Creative media rating per IQG guidelines.
+	Language         string              `json:"language,omitempty"`       // Language of the creative using ISO-639-1-alpha-2.
+	DealID           string              `json:"dealid,omitempty"`         // DealID extension of private marketplace deals
+	Width            int                 `json:"w,omitempty"`              // Width of the ad in pixels.
+	Height           int                 `json:"h,omitempty"`              // Height of the ad in pixels.
+	WidthRatio       int                 `json:"wratio,omitempty"`         // Relative width of the creative when expressing size as a ratio.
+	HeightRatio      int                 `json:"hratio,omitempty"`         // Relative height of the creative when expressing size as a ratio.
+	LangB            string              `json:"langb,omitempty"`          // Language of the creative using IETF BCP 47. Only one of language or langb should be present.
+	Duration         int                 `json:"dur,omitempty"`            // Duration of the video or audio creative in seconds.
+	MarkupType       MarkupType          `json:"mtype,omitempty"`          // Creative markup so that it can properly be associated.
+	SlotInPod        SlotPositionInPod   `json:"slotinpod,omitempty"`      // Indicates that the bid response is only eligible for a specific position.
+	CategoryTaxonomy CategoryTaxonomy    `json:"cattax,omitempty"`         // Defines the taxonomy in use.
+	Exp              int                 `json:"exp,omitempty"`            // Advisory as to the number of seconds the bidder is willing to wait between the auction and the actual impression.
+	Ext              json.RawMessage     `json:"ext,omitempty"`
 }
 
 // Validate required attributes

--- a/openrtb.go
+++ b/openrtb.go
@@ -488,10 +488,10 @@ const (
 	ExpDirFullScreen ExpDir = 5
 )
 
-// APIFramework as defined in section 5.6.
+// APIFramework as defined in Adcom1.0.
 type APIFramework int
 
-// 5.6 API Frameworks
+// API Frameworks options as defined in Adcom1.0.
 const (
 	APIFrameworkUnknown APIFramework = 0
 	APIFrameworkVPAID1  APIFramework = 1
@@ -499,6 +499,10 @@ const (
 	APIFrameworkMRAID1  APIFramework = 3
 	APIFrameworkORMMA   APIFramework = 4
 	APIFrameworkMRAID2  APIFramework = 5
+	APIFrameworkMRAID3  APIFramework = 6
+	APIFrameworkOMID    APIFramework = 7
+	APIFrameworkSIMID1  APIFramework = 8
+	APIFrameworkSIMID11 APIFramework = 9
 )
 
 // VideoLinearity as defined in section 5.7.
@@ -862,4 +866,29 @@ const (
 	SlotPosAny         SlotPositionInPod = 0  // Any ad in the pod.
 	SlotPosFirst       SlotPositionInPod = 1  // First ad in the pod.
 	SlotPosFirstOrLast SlotPositionInPod = 2  // First or Last ad in the pod.
+)
+
+// Type of the creative markup so that it can properly be associated with the right sub-object of the BidRequest.Imp.
+type MarkupType int
+
+// MarkupType available options
+const (
+	MarkupUnknown MarkupType = 0
+	MarkupBanner  MarkupType = 1
+	MarkupVideo   MarkupType = 2
+	MarkupAudio   MarkupType = 3
+	MarkupNative  MarkupType = 4
+)
+
+// CategoryTaxonomy identifies the taxonomy in effect when content categories as defined in Adcom1.0.
+type CategoryTaxonomy int
+
+// CategoryTaxonomy options as defined in Adcom1.0
+const (
+	CategoryTaxonomyIABContent1   CategoryTaxonomy = 1 // 1	IAB Content Category Taxonomy 1.0.
+	CategoryTaxonomyIABContent2   CategoryTaxonomy = 2 // 2	IAB Content Category Taxonomy 2: www.iab.com/guidelines/taxonomy
+	CategoryTaxonomyIABProduct1   CategoryTaxonomy = 3 // 3	IAB Ad Product Taxonomy 1.0.
+	CategoryTaxonomyIABAudience11 CategoryTaxonomy = 4 // 4	IAB Audience Taxonomy 1.1.
+	CategoryTaxonomyIABContent21  CategoryTaxonomy = 5 // 5	IAB Content Category Taxonomy 2.1.
+	CategoryTaxonomyIABContent22  CategoryTaxonomy = 6 // 6	IAB Content Category Taxonomy 2.2
 )

--- a/openrtb.go
+++ b/openrtb.go
@@ -842,3 +842,24 @@ type Format struct {
 	WidthMin    int             `json:"wmin,omitempty"`    // The minimum width in device independent pixels (DIPS) at which the ad will be displayed the size is expressed as a ratio.
 	Ext         json.RawMessage `json:"ext,omitempty"`
 }
+
+// PodSequence identifies the pod sequence field, for use in video content streams with one or more ad pods as defined in Adcom1.0
+type PodSequence int
+
+// PodSequence options as defined in Adcom1.0
+const (
+	PodSeqLast  PodSequence = -1 // Last pod in the content stream.
+	PodSeqAny   PodSequence = 0  // Any pod in the content stream.
+	PodSeqFirst PodSequence = 1  // First pod in the content stream.
+)
+
+// SlotPositionInPod identifies the slot position in pod field, for use in video ad pods as defined in Adcom1.0
+type SlotPositionInPod int
+
+// SlotPositionInPod options as defined in Adcom1.0
+const (
+	SlotPosLast        SlotPositionInPod = -1 // Last ad in the pod.
+	SlotPosAny         SlotPositionInPod = 0  // Any ad in the pod.
+	SlotPosFirst       SlotPositionInPod = 1  // First ad in the pod.
+	SlotPosFirstOrLast SlotPositionInPod = 2  // First or Last ad in the pod.
+)

--- a/video.go
+++ b/video.go
@@ -33,6 +33,12 @@ type Video struct {
 	MinBitrate      int                 `json:"minbitrate,omitempty"`     // Minimum bit rate in Kbps
 	MaxBitrate      int                 `json:"maxbitrate,omitempty"`     // Maximum bit rate in Kbps
 	BoxingAllowed   *int                `json:"boxingallowed,omitempty"`  // If exchange publisher has rules preventing letter boxing
+	PodID           string              `json:"podid,omitempty"`          // Pod id unique identifier for video ad pod
+	PodDuration     int                 `json:"poddur,omitempty"`         // Pod Duration total amount of time in seconds that advertisers may fill for a video ad pod
+	PodSequence     PodSequence         `json:"podseq,omitempty"`         // Pod Sequence position of the video ad pod
+	SlotInPod       SlotPositionInPod   `json:"slotinpod,omitempty"`      // Slot Position in ad
+	RqdDurs         []int64             `json:"rqddurs,omitempty"`        // Precise acceptable durations for video creatives inseconds.
+	MinCPMPerSecond float64             `json:"mincpmpersec,omitempty"`   //   Minimum CPM per second. This is a price floor for the portion of a video ad pod
 	PlaybackMethods []VideoPlayback     `json:"playbackmethod,omitempty"` // List of allowed playback methods
 	Delivery        []ContentDelivery   `json:"delivery,omitempty"`       // List of supported delivery methods
 	Position        AdPosition          `json:"pos,omitempty"`            // Ad Position


### PR DESCRIPTION
Now Bid Object contains:

1. apis
2. langb
3. dur
4. mtype
5. slotinpod
6. cattax

Also updated APIFramework as defined in ADCOM1.0 