### PR TITLE
full support for `langb` fields

### DIFF
--- a/bidrequest.go
+++ b/bidrequest.go
@@ -28,7 +28,7 @@ type BidRequest struct {
 	Seats             []string          `json:"wseat,omitempty"`   // Array of buyer seats allowed to bid on this auction
 	BlockedSeats      []string          `json:"bseat,omitempty"`   // Array of buyer seats blocked to bid on this auction
 	Languages         []string          `json:"wlang,omitempty"`   // Allowed list of languages for creatives using ISO-639-1-alpha-2. Omission implies no specific restrictions, but buyers would be advised to consider language attribute in the Device and/or Content objects if available. Only one of wlang or wlangb should be present.
-	WLangB            []string          `json:"wlangb,omitempty"`  // Allowed list of languages for creatives using IETF BCP 47I. Omission implies no specific restrictions, but buyers would be advised to consider language attribute in the Device and/or Content objects if available. Only one of wlang or wlangb should be present.
+	LanguagesB        []string          `json:"wlangb,omitempty"`  // Allowed list of languages for creatives using IETF BCP 47I. Omission implies no specific restrictions, but buyers would be advised to consider language attribute in the Device and/or Content objects if available. Only one of wlang or wlangb should be present.
 	AllImpressions    int               `json:"allimps,omitempty"` // Flag to indicate whether exchange can verify that all impressions offered represent all of the impressions available in context, Default: 0
 	Currencies        []string          `json:"cur,omitempty"`     // Array of allowed currencies
 	BlockedCategories []ContentCategory `json:"bcat,omitempty"`    // Blocked Advertiser Categories.

--- a/bidrequest.go
+++ b/bidrequest.go
@@ -27,7 +27,8 @@ type BidRequest struct {
 	TimeMax           int               `json:"tmax,omitempty"`    // Maximum amount of time in milliseconds to submit a bid
 	Seats             []string          `json:"wseat,omitempty"`   // Array of buyer seats allowed to bid on this auction
 	BlockedSeats      []string          `json:"bseat,omitempty"`   // Array of buyer seats blocked to bid on this auction
-	Languages         []string          `json:"wlang,omitempty"`   // Array of languages for creatives using ISO-639-1-alpha-2
+	Languages         []string          `json:"wlang,omitempty"`   // Allowed list of languages for creatives using ISO-639-1-alpha-2. Omission implies no specific restrictions, but buyers would be advised to consider language attribute in the Device and/or Content objects if available. Only one of wlang or wlangb should be present.
+	WLangB            []string          `json:"wlangb,omitempty"`  // Allowed list of languages for creatives using IETF BCP 47I. Omission implies no specific restrictions, but buyers would be advised to consider language attribute in the Device and/or Content objects if available. Only one of wlang or wlangb should be present.
 	AllImpressions    int               `json:"allimps,omitempty"` // Flag to indicate whether exchange can verify that all impressions offered represent all of the impressions available in context, Default: 0
 	Currencies        []string          `json:"cur,omitempty"`     // Array of allowed currencies
 	BlockedCategories []ContentCategory `json:"bcat,omitempty"`    // Blocked Advertiser Categories.

--- a/content.go
+++ b/content.go
@@ -19,6 +19,7 @@ type Content struct {
 	ISRC               string            `json:"isrc,omitempty"`               // International Standard Recording Code conforming to ISO - 3901.
 	Producer           *Producer         `json:"producer,omitempty"`           // The producer.
 	URL                string            `json:"url,omitempty"`                // URL of the content, for buy-side contextualization or review.
+	CategoryTaxonomy   CategoryTaxonomy  `json:"cattax,omitempty"`             // Defines the taxonomy in use.
 	Categories         []ContentCategory `json:"cat,omitempty"`                // Array of IAB content categories that describe the content.
 	ProductionQuality  ProductionQuality `json:"prodq,omitempty"`              // Production quality per IAB's classification.
 	VideoQuality       ProductionQuality `json:"videoquality,omitempty"`       // DEPRECATED. Video quality per IAB's classification.
@@ -31,12 +32,11 @@ type Content struct {
 	SourceRelationship int               `json:"sourcerelationship,omitempty"` // 0 = indirect, 1 = direct.
 	Length             int               `json:"len,omitempty"`                // Length of content in seconds; appropriate for video or audio.
 	Language           string            `json:"language,omitempty"`           // Content language using ISO-639-1-alpha-2.
+	LangB              string            `json:"langb,omitempty"`              // Content language using IETF BCP 47. Only one of language or langb should be present.
 	Embeddable         int               `json:"embeddable,omitempty"`         // Indicator of whether or not the content is embeddable (e.g., an embeddable video player), where 0 = no, 1 = yes.
 	Data               []Data            `json:"data,omitempty"`               // Additional content data.
 	Network            *ChannelEntity    `json:"network,omitempty"`            // Details about the network the content is on.
 	Channel            *ChannelEntity    `json:"channel,omitempty"`            // Details about the channel the content is on.
 	KwArray            []string          `json:"kwarray,omitempty"`            // Array of keywords about the site. Only one of ‘keywords’ or‘kwarray’ may be present.
-	CategoryTaxonomy   CategoryTaxonomy  `json:"cattax,omitempty"`             // Defines the taxonomy in use.
-	LangB              string            `json:"langb,omitempty"`              // Language of the creative using IETF BCP 47. Only one of language or langb should be present.
 	Ext                json.RawMessage   `json:"ext,omitempty"`
 }

--- a/content.go
+++ b/content.go
@@ -32,7 +32,7 @@ type Content struct {
 	SourceRelationship int               `json:"sourcerelationship,omitempty"` // 0 = indirect, 1 = direct.
 	Length             int               `json:"len,omitempty"`                // Length of content in seconds; appropriate for video or audio.
 	Language           string            `json:"language,omitempty"`           // Content language using ISO-639-1-alpha-2.
-	LangB              string            `json:"langb,omitempty"`              // Content language using IETF BCP 47. Only one of language or langb should be present.
+	LanguageB          string            `json:"langb,omitempty"`              // Content language using IETF BCP 47. Only one of language or langb should be present.
 	Embeddable         int               `json:"embeddable,omitempty"`         // Indicator of whether or not the content is embeddable (e.g., an embeddable video player), where 0 = no, 1 = yes.
 	Data               []Data            `json:"data,omitempty"`               // Additional content data.
 	Network            *ChannelEntity    `json:"network,omitempty"`            // Details about the network the content is on.

--- a/device.go
+++ b/device.go
@@ -26,7 +26,8 @@ type Device struct {
 	JS           int             `json:"js,omitempty"`             // Javascript status ("0": Disabled, "1": Enabled)
 	GeoFetch     int             `json:"geofetch,omitempty"`       // Indicates if the geolocation API will be available to JavaScript code running in the banner,
 	FlashVersion string          `json:"flashver,omitempty"`       // Flash version
-	Language     string          `json:"language,omitempty"`       // Browser language
+	Language     string          `json:"language,omitempty"`       // Browser language using ISO-639-1-alpha-2. Only one of language or langb should be present.
+	LangB        string          `json:"langb,omitempty"`          // Browser language using IETF BCP 47. Only one of language or langb should be present.
 	Carrier      string          `json:"carrier,omitempty"`        // Carrier or ISP derived from the IP address
 	MCCMNC       string          `json:"mccmnc,omitempty"`         // Mobile carrier as the concatenated MCC-MNC code (e.g., "310-005" identifies Verizon Wireless CDMA in the USA).
 	ConnType     ConnType        `json:"connectiontype,omitempty"` // Network connection type.

--- a/device.go
+++ b/device.go
@@ -27,7 +27,7 @@ type Device struct {
 	GeoFetch     int             `json:"geofetch,omitempty"`       // Indicates if the geolocation API will be available to JavaScript code running in the banner,
 	FlashVersion string          `json:"flashver,omitempty"`       // Flash version
 	Language     string          `json:"language,omitempty"`       // Browser language using ISO-639-1-alpha-2. Only one of language or langb should be present.
-	LangB        string          `json:"langb,omitempty"`          // Browser language using IETF BCP 47. Only one of language or langb should be present.
+	LanguageB    string          `json:"langb,omitempty"`          // Browser language using IETF BCP 47. Only one of language or langb should be present.
 	Carrier      string          `json:"carrier,omitempty"`        // Carrier or ISP derived from the IP address
 	MCCMNC       string          `json:"mccmnc,omitempty"`         // Mobile carrier as the concatenated MCC-MNC code (e.g., "310-005" identifies Verizon Wireless CDMA in the USA).
 	ConnType     ConnType        `json:"connectiontype,omitempty"` // Network connection type.


### PR DESCRIPTION
### Summary
Open RTB 2.6 added support for a new language specification (IETF BCP 47) on `BidRequest`, `Device`, and `Content` objects in the form of an alternate language field called `wlangb` or `langb`. A [recently merged PR](https://github.com/bsm/openrtb/pull/108) added `langb` to the `Content` obj. This PR fully incorporates the new language fields, allowing for complete OpenRTB 2.6 support of all language fields in all associated objects.

#### BidRequest
`wlangb []string`

#### Device
`langb string`

#### Content
`langb string`

Note, aside from simply adding the fields, I've put the 2 lang fields near each other in the respective files. Also moved `cattax` to be near `cat` since they are also tightly coupled. Lastly, I made sure the comments were word for word what's in the [OpenRTB 2.6 spec](https://iabtechlab.com/wp-content/uploads/2022/04/OpenRTB-2-6_FINAL.pdf), as I felt some important information was left out.

#### Additional Context from OpenRTB 2.6
```
Added new language field to support IETF BCP 47
IETF BCP 47 offers additional layers of granularity, for example, differentiating written language
versions of the same spoken language (e.g. Traditional and Simplified Chinese)
https://en.wikipedia.org/wiki/IETF_language_tag
```

Would like to request a new minor release after merging.